### PR TITLE
Fix medias mapping on comment entity

### DIFF
--- a/src/Blog/Domain/Entity/Comment.php
+++ b/src/Blog/Domain/Entity/Comment.php
@@ -90,7 +90,7 @@ class Comment implements EntityInterface
     ])]
     private Collection $children;
 
-    #[ORM\Column(type: 'uuid', nullable: true)]
+    #[ORM\Column(type: Types::JSON, nullable: true)]
     #[Groups([
         'Comment',
         'Comment.medias',
@@ -128,6 +128,7 @@ class Comment implements EntityInterface
         $this->children = new ArrayCollection();
         $this->likes = new ArrayCollection();
         $this->reactions = new ArrayCollection();
+        $this->medias = [];
     }
 
     public function __toString(): string
@@ -218,12 +219,16 @@ class Comment implements EntityInterface
         $this->post = $post;
     }
 
-    /**
-     * @return array|null
-     */
-    public function getMedias(): ?array
+    public function getMedias(): array
     {
-        return $this->medias;
+        return $this->medias ?? [];
+    }
+
+    public function setMedias(?array $medias): self
+    {
+        $this->medias = $medias ?? [];
+
+        return $this;
     }
 
     public function getLikes(): Collection


### PR DESCRIPTION
## Summary
- map the comment medias association to a JSON column so Doctrine persists the array data correctly
- default medias to an empty collection and add accessors that normalize null inputs

## Testing
- php bin/console doctrine:schema:validate *(fails: missing vendor dependencies; composer install requires GitHub credentials in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d306cbdc008326b41d758cfdce24b5