### PR TITLE
Fix media association inverse property and nullable type

### DIFF
--- a/src/Blog/Domain/Entity/Media.php
+++ b/src/Blog/Domain/Entity/Media.php
@@ -41,9 +41,9 @@ class Media
 
     #[ORM\Column(type: Types::STRING, length: 50, nullable: true)]
     #[Groups(['Media', 'Post'])]
-    private string $type;
+    private ?string $type = null;
 
-    #[ORM\ManyToOne(targetEntity: Post::class, inversedBy: 'mediaEntities')]
+    #[ORM\ManyToOne(targetEntity: Post::class, inversedBy: 'medias')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     private Post $post;
 
@@ -74,12 +74,12 @@ class Media
         return $this;
     }
 
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->type;
     }
 
-    public function setType(string $type): self
+    public function setType(?string $type): self
     {
         $this->type = $type;
 


### PR DESCRIPTION
## Summary
- point Media::post relation to the Post::$medias inverse collection
- allow nullable media types so Doctrine can hydrate null values

## Testing
- `php bin/console doctrine:cache:clear-metadata` *(fails: dependencies missing because composer install cannot complete without GitHub access tokens)*
- `composer install` *(fails: requires ext-amqp and ext-sodium which are unavailable in the environment)*
- `composer install --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium` *(fails: network access to GitHub is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d306cd2da4832697169d5a8db8a64c