### PR TITLE
Fix blog DTO mapping and add controller tests

### DIFF
--- a/src/Blog/Application/DTO/Blog/Blog.php
+++ b/src/Blog/Application/DTO/Blog/Blog.php
@@ -8,10 +8,15 @@ use App\Blog\Domain\Entity\Blog as Entity;
 use App\General\Application\DTO\Interfaces\RestDtoInterface;
 use App\General\Application\DTO\RestDto;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
-use DateTimeInterface;
 use Override;
+use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Validator\Constraints as Assert;
+
+use const FILTER_NULL_ON_FAILURE;
+use const FILTER_VALIDATE_BOOLEAN;
+use function filter_var;
+use function is_bool;
 
 /**
  * @package App\Blog
@@ -22,46 +27,31 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class Blog extends RestDto
 {
-
-    #[Assert\NotBlank(message: 'User ID cannot be blank.')]
-    protected UuidInterface $userId;
-
     #[Assert\NotBlank]
     #[Assert\NotNull]
     #[Assert\Length(min: 2, max: 255)]
-    protected string $title= '';
+    protected string $title = '';
 
-    #[Assert\NotBlank]
+    #[Assert\Length(max: 250)]
+    protected ?string $blogSubtitle = null;
+
     #[Assert\NotNull]
-    protected string $description = '';
+    protected UuidInterface $author;
 
-    #[Assert\NotBlank]
-    #[Assert\NotNull]
-    protected string $gender = '';
+    #[Assert\Length(max: 255)]
+    protected ?string $logo = null;
 
-    protected UuidInterface $photo;
+    #[Assert\Type('array')]
+    protected ?array $teams = null;
 
-    #[Assert\Date(message: 'The birthday must be a valid date.')]
-    protected ?DateTimeInterface $birthday = null;
+    #[Assert\Type('bool')]
+    protected ?bool $visible = null;
 
-    protected ?string $googleId = "";
+    #[Assert\Length(max: 255)]
+    protected ?string $slug = null;
 
-    protected ?string $githubId = "";
-
-    protected ?string $githubUrl = "";
-
-    protected ?string $instagramUrl = "";
-
-    protected ?string $linkedInId = "";
-
-    protected ?string $linkedInUrl = "";
-
-    protected ?string $twitterUrl = "";
-
-    protected ?string $facebookUrl = "";
-
-    protected ?string $phone = "";
-
+    #[Assert\Length(max: 36)]
+    protected ?string $color = null;
 
     public function getTitle(): string
     {
@@ -76,184 +66,108 @@ class Blog extends RestDto
         return $this;
     }
 
-    public function getDescription(): string
+    public function getBlogSubtitle(): ?string
     {
-        return $this->description;
+        return $this->blogSubtitle;
     }
 
-    public function setDescription(string $description): self
+    public function setBlogSubtitle(?string $blogSubtitle): self
     {
-        $this->setVisited('description');
-        $this->description = $description;
+        $this->setVisited('blogSubtitle');
+        $this->blogSubtitle = $blogSubtitle;
 
         return $this;
     }
 
-    public function getUserId(): UuidInterface
+    public function getAuthor(): UuidInterface
     {
-        return $this->userId;
+        return $this->author;
     }
 
-    public function setUserId(UuidInterface $userId): self
+    /**
+     * @param UuidInterface|string $author
+     */
+    public function setAuthor(UuidInterface|string $author): self
     {
-        $this->setVisited('userId');
-        $this->userId = $userId;
+        $this->setVisited('author');
+        $this->author = $author instanceof UuidInterface ? $author : Uuid::fromString($author);
 
         return $this;
     }
 
-    public function getGender(): string
+    public function getLogo(): ?string
     {
-        return $this->gender;
+        return $this->logo;
     }
 
-    public function setGender(string $gender): self
+    public function setLogo(?string $logo): self
     {
-        $this->setVisited('gender');
-        $this->gender = $gender;
+        $this->setVisited('logo');
+        $this->logo = $logo;
 
         return $this;
     }
 
-    public function getPhoto(): UuidInterface
+    /**
+     * @return array<int, mixed>|null
+     */
+    public function getTeams(): ?array
     {
-        return $this->photo;
+        return $this->teams;
     }
 
-    public function setPhoto(UuidInterface $photo): self
+    /**
+     * @param array<int, mixed>|null $teams
+     */
+    public function setTeams(?array $teams): self
     {
-        $this->setVisited('photo');
-        $this->photo = $photo;
+        $this->setVisited('teams');
+        $this->teams = $teams;
 
         return $this;
     }
 
-    public function getBirthday(): ?DateTimeInterface
+    public function getVisible(): ?bool
     {
-        return $this->birthday;
+        return $this->visible;
     }
 
-    public function setBirthday(?DateTimeInterface $birthday): self
+    public function setVisible(bool|string|null $visible): self
     {
-        $this->setVisited('birthday');
-        $this->birthday = $birthday;
+        $this->setVisited('visible');
+        if ($visible === null) {
+            $this->visible = null;
+        } else {
+            $this->visible = is_bool($visible)
+                ? $visible
+                : filter_var($visible, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? (bool)$visible;
+        }
 
         return $this;
     }
 
-    public function getGoogleId(): ?string
+    public function getSlug(): ?string
     {
-        return $this->googleId;
+        return $this->slug;
     }
 
-    public function setGoogleId(?string $googleId): self
+    public function setSlug(?string $slug): self
     {
-        $this->setVisited('googleId');
-        $this->googleId = $googleId;
+        $this->setVisited('slug');
+        $this->slug = $slug;
 
         return $this;
     }
 
-    public function getGithubId(): ?string
+    public function getColor(): ?string
     {
-        return $this->githubId;
+        return $this->color;
     }
 
-    public function setGithubId(?string $githubId): self
+    public function setColor(?string $color): self
     {
-        $this->setVisited('githubId');
-        $this->githubId = $githubId;
-
-        return $this;
-    }
-
-    public function getGithubUrl(): ?string
-    {
-        return $this->githubUrl;
-    }
-
-    public function setGithubUrl(?string $githubUrl): self
-    {
-        $this->setVisited('githubUrl');
-        $this->githubUrl = $githubUrl;
-
-        return $this;
-    }
-
-    public function getInstagramUrl(): ?string
-    {
-        return $this->instagramUrl;
-    }
-
-    public function setInstagramUrl(?string $instagramUrl): self
-    {
-        $this->setVisited('instagramUrl');
-        $this->instagramUrl = $instagramUrl;
-
-        return $this;
-    }
-
-    public function getLinkedInId(): ?string
-    {
-        return $this->linkedInId;
-    }
-
-    public function setLinkedInId(?string $linkedInId): self
-    {
-        $this->setVisited('linkedInId');
-        $this->linkedInId = $linkedInId;
-
-        return $this;
-    }
-
-    public function getLinkedInUrl(): ?string
-    {
-        return $this->linkedInUrl;
-    }
-
-    public function setLinkedInUrl(?string $linkedInUrl): self
-    {
-        $this->setVisited('linkedInUrl');
-        $this->linkedInUrl = $linkedInUrl;
-
-        return $this;
-    }
-
-    public function getTwitterUrl(): ?string
-    {
-        return $this->twitterUrl;
-    }
-
-    public function setTwitterUrl(?string $twitterUrl): self
-    {
-        $this->setVisited('twitterUrl');
-        $this->twitterUrl = $twitterUrl;
-
-        return $this;
-    }
-
-    public function getFacebookUrl(): ?string
-    {
-        return $this->facebookUrl;
-    }
-
-    public function setFacebookUrl(?string $facebookUrl): self
-    {
-        $this->setVisited('facebookUrl');
-        $this->facebookUrl = $facebookUrl;
-
-        return $this;
-    }
-
-    public function getPhone(): ?string
-    {
-        return $this->phone;
-    }
-
-    public function setPhone(?string $phone): self
-    {
-        $this->setVisited('phone');
-        $this->phone = $phone;
+        $this->setVisited('color');
+        $this->color = $color;
 
         return $this;
     }
@@ -269,20 +183,13 @@ class Blog extends RestDto
         if ($entity instanceof Entity) {
             $this->id = $entity->getId();
             $this->title = $entity->getTitle();
-            $this->description = $entity->getDescription();
-            $this->userId = $entity->getUserId();
-            $this->photo = $entity->getPhoto();
-            $this->birthday = $entity->getBirthday();
-            $this->gender = $entity->getGender();
-            $this->googleId = $entity->getGoogleId();
-            $this->githubId = $entity->getGithubId();
-            $this->githubUrl = $entity->getGithubUrl();
-            $this->instagramUrl = $entity->getInstagramUrl();
-            $this->linkedInId = $entity->getLinkedInId();
-            $this->linkedInUrl = $entity->getLinkedInUrl();
-            $this->twitterUrl = $entity->getTwitterUrl();
-            $this->facebookUrl = $entity->getFacebookUrl();
-            $this->phone = $entity->getPhone();
+            $this->blogSubtitle = $entity->getBlogSubtitle();
+            $this->author = $entity->getAuthor();
+            $this->logo = $entity->getLogo();
+            $this->teams = $entity->getTeams();
+            $this->visible = $entity->isVisible();
+            $this->slug = $entity->getSlug();
+            $this->color = $entity->getColor();
         }
 
         return $this;

--- a/src/Blog/Transport/AutoMapper/Blog/RequestMapper.php
+++ b/src/Blog/Transport/AutoMapper/Blog/RequestMapper.php
@@ -16,19 +16,12 @@ class RequestMapper extends RestRequestMapper
      */
     protected static array $properties = [
         'title',
-        'description',
-        'userId',
-        'photo',
-        'birthday',
-        'gender',
-        'googleId',
-        'githubId',
-        'githubUrl',
-        'instagramUrl',
-        'linkedInId',
-        'linkedInUrl',
-        'twitterUrl',
-        'facebookUrl',
-        'phone'
+        'blogSubtitle',
+        'author',
+        'logo',
+        'teams',
+        'visible',
+        'slug',
+        'color',
     ];
 }

--- a/tests/Application/Blog/Transport/Controller/Api/BlogControllerTest.php
+++ b/tests/Application/Blog/Transport/Controller/Api/BlogControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Blog\Transport\Controller\Api;
+
+use App\Blog\Domain\Entity\Blog;
+use App\Tests\TestCase\WebTestCase;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * @package App\Tests\Application\Blog\Transport\Controller\Api
+ */
+final class BlogControllerTest extends WebTestCase
+{
+    /**
+     * @throws Throwable
+     */
+    public function testBlogCanBeCreatedThroughApi(): void
+    {
+        $client = static::createClient();
+        $payload = [
+            'title' => 'Test Blog ' . uniqid('', true),
+            'blogSubtitle' => 'Subtitle for test blog',
+            'author' => Uuid::uuid1()->toString(),
+            'logo' => 'https://example.com/logo.png',
+            'teams' => ['alpha', 'beta'],
+            'visible' => false,
+            'color' => '#123abc',
+        ];
+
+        $client->jsonRequest('POST', '/api/v1/blog', $payload);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        $data = json_decode($client->getResponse()->getContent() ?: '', true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+        self::assertArrayHasKey('id', $data);
+
+        /** @var ManagerRegistry $registry */
+        $registry = static::getContainer()->get('doctrine');
+        $blog = $registry->getRepository(Blog::class)->findOneBy(['title' => $payload['title']]);
+
+        self::assertInstanceOf(Blog::class, $blog);
+        self::assertSame($payload['blogSubtitle'], $blog->getBlogSubtitle());
+        self::assertSame($payload['logo'], $blog->getLogo());
+        self::assertSame($payload['teams'], $blog->getTeams());
+        self::assertSame($payload['author'], $blog->getAuthor()->toString());
+        self::assertSame($payload['visible'], $blog->isVisible());
+        self::assertSame($payload['color'], $blog->getColor());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testBlogCanBeUpdatedThroughApi(): void
+    {
+        /** @var ManagerRegistry $registry */
+        $registry = static::getContainer()->get('doctrine');
+        $repository = $registry->getRepository(Blog::class);
+        $existing = $repository->findOneBy(['title' => 'public']);
+
+        self::assertInstanceOf(Blog::class, $existing);
+
+        $client = static::createClient();
+        $payload = [
+            'title' => 'Updated Blog ' . uniqid('', true),
+            'blogSubtitle' => 'Updated subtitle',
+            'logo' => 'https://example.com/updated-logo.png',
+            'teams' => ['delta'],
+            'visible' => true,
+        ];
+
+        $client->jsonRequest('PUT', '/api/v1/blog/' . $existing->getId(), $payload);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_OK);
+
+        $registry->getManager()->clear();
+        $updated = $repository->find(Uuid::fromString($existing->getId()));
+
+        self::assertInstanceOf(Blog::class, $updated);
+        self::assertSame($payload['title'], $updated->getTitle());
+        self::assertSame($payload['blogSubtitle'], $updated->getBlogSubtitle());
+        self::assertSame($payload['logo'], $updated->getLogo());
+        self::assertSame($payload['teams'], $updated->getTeams());
+        self::assertSame($payload['visible'], $updated->isVisible());
+    }
+}


### PR DESCRIPTION
## Summary
- replace the Blog DTO profile fields with the real Blog entity attributes and align validation
- map incoming Blog requests to the new DTO fields
- add functional API tests that cover creating and updating blogs via BlogController

## Testing
- `vendor/bin/phpunit --testsuite Application --filter BlogControllerTest` *(fails: phpunit not installed because Composer cannot download dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d310ad4aac8326a4e640fd1b5e0e5c