### PR TITLE
Align like DTO with entity and cover mapping

### DIFF
--- a/src/Blog/Application/DTO/Like/Like.php
+++ b/src/Blog/Application/DTO/Like/Like.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Blog\Application\DTO\Like;
 
+use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Entity\Like as Entity;
+use App\Blog\Domain\Entity\Post;
 use App\General\Application\DTO\Interfaces\RestDtoInterface;
 use App\General\Application\DTO\RestDto;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
-use DateTimeInterface;
+use DateTimeImmutable;
 use Override;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -22,238 +24,78 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 class Like extends RestDto
 {
+    #[Assert\NotNull(message: 'User cannot be null.')]
+    protected UuidInterface $user;
 
-    #[Assert\NotBlank(message: 'User ID cannot be blank.')]
-    protected UuidInterface $userId;
+    protected ?Post $post = null;
 
-    #[Assert\NotBlank]
-    #[Assert\NotNull]
-    #[Assert\Length(min: 2, max: 255)]
-    protected string $title= '';
+    protected ?Comment $comment = null;
 
-    #[Assert\NotBlank]
-    #[Assert\NotNull]
-    protected string $description = '';
+    protected ?DateTimeImmutable $createdAt = null;
 
-    #[Assert\NotBlank]
-    #[Assert\NotNull]
-    protected string $gender = '';
+    protected ?DateTimeImmutable $updatedAt = null;
 
-    protected UuidInterface $photo;
-
-    #[Assert\Date(message: 'The birthday must be a valid date.')]
-    protected ?DateTimeInterface $birthday = null;
-
-    protected ?string $googleId = "";
-
-    protected ?string $githubId = "";
-
-    protected ?string $githubUrl = "";
-
-    protected ?string $instagramUrl = "";
-
-    protected ?string $linkedInId = "";
-
-    protected ?string $linkedInUrl = "";
-
-    protected ?string $twitterUrl = "";
-
-    protected ?string $facebookUrl = "";
-
-    protected ?string $phone = "";
-
-
-    public function getTitle(): string
+    public function getUser(): UuidInterface
     {
-        return $this->title;
+        return $this->user;
     }
 
-    public function setTitle(string $title): self
+    public function setUser(UuidInterface $user): self
     {
-        $this->setVisited('title');
-        $this->title = $title;
+        $this->setVisited('user');
+        $this->user = $user;
 
         return $this;
     }
 
-    public function getDescription(): string
+    public function getPost(): ?Post
     {
-        return $this->description;
+        return $this->post;
     }
 
-    public function setDescription(string $description): self
+    public function setPost(?Post $post): self
     {
-        $this->setVisited('description');
-        $this->description = $description;
+        $this->setVisited('post');
+        $this->post = $post;
 
         return $this;
     }
 
-    public function getUserId(): UuidInterface
+    public function getComment(): ?Comment
     {
-        return $this->userId;
+        return $this->comment;
     }
 
-    public function setUserId(UuidInterface $userId): self
+    public function setComment(?Comment $comment): self
     {
-        $this->setVisited('userId');
-        $this->userId = $userId;
+        $this->setVisited('comment');
+        $this->comment = $comment;
 
         return $this;
     }
 
-    public function getGender(): string
+    public function getCreatedAt(): ?DateTimeImmutable
     {
-        return $this->gender;
+        return $this->createdAt;
     }
 
-    public function setGender(string $gender): self
+    public function setCreatedAt(DateTimeImmutable $createdAt): self
     {
-        $this->setVisited('gender');
-        $this->gender = $gender;
+        $this->setVisited('createdAt');
+        $this->createdAt = $createdAt;
 
         return $this;
     }
 
-    public function getPhoto(): UuidInterface
+    public function getUpdatedAt(): ?DateTimeImmutable
     {
-        return $this->photo;
+        return $this->updatedAt;
     }
 
-    public function setPhoto(UuidInterface $photo): self
+    public function setUpdatedAt(DateTimeImmutable $updatedAt): self
     {
-        $this->setVisited('photo');
-        $this->photo = $photo;
-
-        return $this;
-    }
-
-    public function getBirthday(): ?DateTimeInterface
-    {
-        return $this->birthday;
-    }
-
-    public function setBirthday(?DateTimeInterface $birthday): self
-    {
-        $this->setVisited('birthday');
-        $this->birthday = $birthday;
-
-        return $this;
-    }
-
-    public function getGoogleId(): ?string
-    {
-        return $this->googleId;
-    }
-
-    public function setGoogleId(?string $googleId): self
-    {
-        $this->setVisited('googleId');
-        $this->googleId = $googleId;
-
-        return $this;
-    }
-
-    public function getGithubId(): ?string
-    {
-        return $this->githubId;
-    }
-
-    public function setGithubId(?string $githubId): self
-    {
-        $this->setVisited('githubId');
-        $this->githubId = $githubId;
-
-        return $this;
-    }
-
-    public function getGithubUrl(): ?string
-    {
-        return $this->githubUrl;
-    }
-
-    public function setGithubUrl(?string $githubUrl): self
-    {
-        $this->setVisited('githubUrl');
-        $this->githubUrl = $githubUrl;
-
-        return $this;
-    }
-
-    public function getInstagramUrl(): ?string
-    {
-        return $this->instagramUrl;
-    }
-
-    public function setInstagramUrl(?string $instagramUrl): self
-    {
-        $this->setVisited('instagramUrl');
-        $this->instagramUrl = $instagramUrl;
-
-        return $this;
-    }
-
-    public function getLinkedInId(): ?string
-    {
-        return $this->linkedInId;
-    }
-
-    public function setLinkedInId(?string $linkedInId): self
-    {
-        $this->setVisited('linkedInId');
-        $this->linkedInId = $linkedInId;
-
-        return $this;
-    }
-
-    public function getLinkedInUrl(): ?string
-    {
-        return $this->linkedInUrl;
-    }
-
-    public function setLinkedInUrl(?string $linkedInUrl): self
-    {
-        $this->setVisited('linkedInUrl');
-        $this->linkedInUrl = $linkedInUrl;
-
-        return $this;
-    }
-
-    public function getTwitterUrl(): ?string
-    {
-        return $this->twitterUrl;
-    }
-
-    public function setTwitterUrl(?string $twitterUrl): self
-    {
-        $this->setVisited('twitterUrl');
-        $this->twitterUrl = $twitterUrl;
-
-        return $this;
-    }
-
-    public function getFacebookUrl(): ?string
-    {
-        return $this->facebookUrl;
-    }
-
-    public function setFacebookUrl(?string $facebookUrl): self
-    {
-        $this->setVisited('facebookUrl');
-        $this->facebookUrl = $facebookUrl;
-
-        return $this;
-    }
-
-    public function getPhone(): ?string
-    {
-        return $this->phone;
-    }
-
-    public function setPhone(?string $phone): self
-    {
-        $this->setVisited('phone');
-        $this->phone = $phone;
+        $this->setVisited('updatedAt');
+        $this->updatedAt = $updatedAt;
 
         return $this;
     }
@@ -268,21 +110,11 @@ class Like extends RestDto
     {
         if ($entity instanceof Entity) {
             $this->id = $entity->getId();
-            $this->title = $entity->getTitle();
-            $this->description = $entity->getDescription();
-            $this->userId = $entity->getUserId();
-            $this->photo = $entity->getPhoto();
-            $this->birthday = $entity->getBirthday();
-            $this->gender = $entity->getGender();
-            $this->googleId = $entity->getGoogleId();
-            $this->githubId = $entity->getGithubId();
-            $this->githubUrl = $entity->getGithubUrl();
-            $this->instagramUrl = $entity->getInstagramUrl();
-            $this->linkedInId = $entity->getLinkedInId();
-            $this->linkedInUrl = $entity->getLinkedInUrl();
-            $this->twitterUrl = $entity->getTwitterUrl();
-            $this->facebookUrl = $entity->getFacebookUrl();
-            $this->phone = $entity->getPhone();
+            $this->user = $entity->getUser();
+            $this->post = $entity->getPost();
+            $this->comment = $entity->getComment();
+            $this->createdAt = $entity->getCreatedAt();
+            $this->updatedAt = $entity->getUpdatedAt();
         }
 
         return $this;

--- a/src/Blog/Transport/AutoMapper/Like/RequestMapper.php
+++ b/src/Blog/Transport/AutoMapper/Like/RequestMapper.php
@@ -4,7 +4,15 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\AutoMapper\Like;
 
+use App\Blog\Domain\Entity\Comment;
+use App\Blog\Domain\Entity\Post;
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
 use App\General\Transport\AutoMapper\RestRequestMapper;
+use Doctrine\Persistence\ManagerRegistry;
+use Override;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @package App\Like
@@ -15,20 +23,82 @@ class RequestMapper extends RestRequestMapper
      * @var array<int, non-empty-string>
      */
     protected static array $properties = [
-        'title',
-        'description',
-        'userId',
-        'photo',
-        'birthday',
-        'gender',
-        'googleId',
-        'githubId',
-        'githubUrl',
-        'instagramUrl',
-        'linkedInId',
-        'linkedInUrl',
-        'twitterUrl',
-        'facebookUrl',
-        'phone'
+        'user',
+        'post',
+        'comment',
     ];
+
+    /**
+     * @var array<string, string>
+     */
+    private static array $requestPropertyMap = [
+        'user' => 'userId',
+        'post' => 'postId',
+        'comment' => 'commentId',
+    ];
+
+    public function __construct(private readonly ManagerRegistry $managerRegistry)
+    {
+    }
+
+    #[Override]
+    public function mapToObject($source, $destination, array $context = []): RestDtoInterface
+    {
+        if ($source instanceof Request) {
+            foreach (self::$requestPropertyMap as $property => $requestKey) {
+                if (!$source->request->has($requestKey) || $source->request->has($property)) {
+                    continue;
+                }
+
+                $value = $source->request->get($requestKey);
+
+                if ($value === null || $value === '') {
+                    continue;
+                }
+
+                $source->request->set($property, $value);
+            }
+        }
+
+        return parent::mapToObject($source, $destination, $context);
+    }
+
+    private function transformUser(mixed $value): ?UuidInterface
+    {
+        if ($value instanceof UuidInterface) {
+            return $value;
+        }
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return Uuid::fromString((string) $value);
+    }
+
+    private function transformPost(mixed $value): ?Post
+    {
+        return $this->resolveAssociation($value, Post::class);
+    }
+
+    private function transformComment(mixed $value): ?Comment
+    {
+        return $this->resolveAssociation($value, Comment::class);
+    }
+
+    private function resolveAssociation(mixed $value, string $class): ?object
+    {
+        if ($value instanceof $class) {
+            return $value;
+        }
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $uuid = $value instanceof UuidInterface ? $value : Uuid::fromString((string) $value);
+        $manager = $this->managerRegistry->getManagerForClass($class);
+
+        return $manager?->getReference($class, $uuid);
+    }
 }

--- a/tests/Unit/Blog/Application/Resource/LikeResourceTest.php
+++ b/tests/Unit/Blog/Application/Resource/LikeResourceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Blog\Application\Resource;
+
+use App\Blog\Application\DTO\Like\Like as LikeDto;
+use App\Blog\Application\Resource\LikeResource;
+use App\Blog\Domain\Entity\Comment;
+use App\Blog\Domain\Entity\Like as LikeEntity;
+use App\Blog\Domain\Entity\Post;
+use App\Blog\Infrastructure\Repository\LikeRepository;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Validator\Validation;
+
+/**
+ * @covers \App\Blog\Application\Resource\LikeResource
+ */
+final class LikeResourceTest extends TestCase
+{
+    public function testLikeCanBeCreatedAndUpdated(): void
+    {
+        $storage = [];
+        $repository = $this->createMock(LikeRepository::class);
+        $repository->method('getEntityName')->willReturn(LikeEntity::class);
+        $repository->method('find')->willReturnCallback(
+            static function (
+                string $id,
+                ?int $lockMode = null,
+                ?int $lockVersion = null,
+                ?string $entityManagerName = null
+            ) use (&$storage): ?LikeEntity {
+                return $storage[$id] ?? null;
+            }
+        );
+        $repository->method('save')->willReturnCallback(
+            static function (
+                EntityInterface $entity,
+                ?bool $flush = null,
+                ?bool $skipValidation = null,
+                ?string $entityManagerName = null
+            ) use (&$storage, &$repository): LikeRepository {
+                $storage[$entity->getId()] = $entity;
+
+                return $repository;
+            }
+        );
+
+        $resource = new LikeResource($repository);
+        $resource->setValidator(Validation::createValidator());
+
+        $dto = (new LikeDto())
+            ->setUser(Uuid::uuid4())
+            ->setPost(new Post());
+
+        $entity = $resource->create($dto, flush: false, skipValidation: true);
+
+        self::assertInstanceOf(LikeEntity::class, $entity);
+        self::assertSame($dto->getUser(), $entity->getUser());
+        self::assertSame($dto->getPost(), $entity->getPost());
+        self::assertNull($entity->getComment());
+
+        $comment = new Comment();
+        $updateDto = (new LikeDto())
+            ->setUser($dto->getUser())
+            ->setPost(null)
+            ->setComment($comment);
+
+        $resource->update($entity->getId(), $updateDto, flush: false, skipValidation: true);
+
+        $updated = $storage[$entity->getId()];
+        self::assertSame($comment, $updated->getComment());
+        self::assertNull($updated->getPost());
+    }
+}

--- a/tests/Unit/Blog/Transport/AutoMapper/Like/RequestMapperTest.php
+++ b/tests/Unit/Blog/Transport/AutoMapper/Like/RequestMapperTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Blog\Transport\AutoMapper\Like;
+
+use App\Blog\Application\DTO\Like\Like as LikeDto;
+use App\Blog\Domain\Entity\Comment;
+use App\Blog\Domain\Entity\Post;
+use App\Blog\Transport\AutoMapper\Like\RequestMapper;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @covers \App\Blog\Transport\AutoMapper\Like\RequestMapper
+ */
+final class RequestMapperTest extends TestCase
+{
+    public function testRequestMapperPopulatesEntityReferences(): void
+    {
+        $userId = Uuid::uuid4();
+        $postId = Uuid::uuid4();
+        $commentId = Uuid::uuid4();
+        $postReference = new Post();
+        $commentReference = new Comment();
+
+        $postManager = $this->createMock(ObjectManager::class);
+        $postManager->expects(self::once())
+            ->method('getReference')
+            ->with(Post::class, $postId)
+            ->willReturn($postReference);
+
+        $commentManager = $this->createMock(ObjectManager::class);
+        $commentManager->expects(self::once())
+            ->method('getReference')
+            ->with(Comment::class, $commentId)
+            ->willReturn($commentReference);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->expects(self::exactly(2))
+            ->method('getManagerForClass')
+            ->willReturnMap([
+                [Post::class, $postManager],
+                [Comment::class, $commentManager],
+            ]);
+
+        $mapper = new RequestMapper($registry);
+        $request = new Request([], [
+            'userId' => $userId->toString(),
+            'postId' => $postId->toString(),
+            'commentId' => $commentId->toString(),
+        ]);
+
+        /** @var LikeDto $dto */
+        $dto = $mapper->map($request, LikeDto::class);
+
+        self::assertTrue($userId->equals($dto->getUser()));
+        self::assertSame($postReference, $dto->getPost());
+        self::assertSame($commentReference, $dto->getComment());
+    }
+
+    public function testRequestMapperSkipsMissingAssociations(): void
+    {
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->expects(self::never())->method('getManagerForClass');
+
+        $mapper = new RequestMapper($registry);
+        $request = new Request([], [
+            'userId' => Uuid::uuid4()->toString(),
+        ]);
+
+        /** @var LikeDto $dto */
+        $dto = $mapper->map($request, LikeDto::class);
+
+        self::assertNull($dto->getPost());
+        self::assertNull($dto->getComment());
+    }
+}


### PR DESCRIPTION
## Summary
- align the Like DTO with the entity associations and timestamps
- update the Like request mapper to resolve request identifiers into entity references
- add unit coverage for LikeResource create/update flows and the Like request mapper

## Testing
- php -l src/Blog/Application/DTO/Like/Like.php
- php -l src/Blog/Transport/AutoMapper/Like/RequestMapper.php
- php -l tests/Unit/Blog/Application/Resource/LikeResourceTest.php
- php -l tests/Unit/Blog/Transport/AutoMapper/Like/RequestMapperTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d310b8feb4832692d499e805dd4aee