### PR TITLE
Refine post DTO mapping and add resource tests

### DIFF
--- a/src/Blog/Transport/AutoMapper/Post/RequestMapper.php
+++ b/src/Blog/Transport/AutoMapper/Post/RequestMapper.php
@@ -4,7 +4,18 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\AutoMapper\Post;
 
+use App\Blog\Application\Resource\BlogResource;
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Entity\Tag;
+use App\Blog\Domain\Repository\Interfaces\TagRepositoryInterface;
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
 use App\General\Transport\AutoMapper\RestRequestMapper;
+use DateTimeImmutable;
+use Override;
+use Symfony\Component\HttpFoundation\Request;
+
+use function is_array;
+use function is_string;
 
 /**
  * @package App\Post
@@ -16,19 +27,107 @@ class RequestMapper extends RestRequestMapper
      */
     protected static array $properties = [
         'title',
-        'description',
-        'userId',
-        'photo',
-        'birthday',
-        'gender',
-        'googleId',
-        'githubId',
-        'githubUrl',
-        'instagramUrl',
-        'linkedInId',
-        'linkedInUrl',
-        'twitterUrl',
-        'facebookUrl',
-        'phone'
+        'url',
+        'summary',
+        'content',
+        'author',
+        'blog',
+        'tags',
+        'mediaIds',
+        'publishedAt',
     ];
+
+    public function __construct(
+        private readonly BlogResource $blogResource,
+        private readonly TagRepositoryInterface $tagRepository,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[Override]
+    public function mapToObject($source, $destination, array $context = []): RestDtoInterface
+    {
+        if ($source instanceof Request) {
+            $this->normalizeAliases($source);
+        }
+
+        return parent::mapToObject($source, $destination, $context);
+    }
+
+    private function normalizeAliases(Request $request): void
+    {
+        if ($request->request->has('authorId')) {
+            $request->request->set('author', $request->request->get('authorId'));
+        }
+
+        if ($request->request->has('blogId')) {
+            $request->request->set('blog', $request->request->get('blogId'));
+        }
+
+        if ($request->request->has('tagIds')) {
+            $request->request->set('tags', $request->request->all('tagIds'));
+        }
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected function transformBlog(mixed $value): ?Blog
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof Blog) {
+            return $value;
+        }
+
+        return $this->blogResource->getReference((string)$value);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return array<int, Tag>
+     */
+    protected function transformTags(mixed $value): array
+    {
+        if (!is_array($value) || $value === []) {
+            return [];
+        }
+
+        $tags = [];
+
+        foreach ($value as $id) {
+            if (!is_string($id) || $id === '') {
+                continue;
+            }
+
+            $tag = $this->tagRepository->find($id);
+
+            if ($tag instanceof Tag) {
+                $tags[] = $tag;
+            }
+        }
+
+        return $tags;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected function transformPublishedAt(mixed $value): ?DateTimeImmutable
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if ($value instanceof DateTimeImmutable) {
+            return $value;
+        }
+
+        return new DateTimeImmutable((string)$value);
+    }
 }

--- a/tests/Application/Blog/Application/Resource/PostResourceTest.php
+++ b/tests/Application/Blog/Application/Resource/PostResourceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Blog\Application\Resource;
+
+use App\Blog\Application\DTO\Post\PostCreate;
+use App\Blog\Application\DTO\Post\PostPatch;
+use App\Blog\Application\Resource\PostResource;
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Entity\Post;
+use App\Blog\Domain\Entity\Tag;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+use function sprintf;
+use function str_repeat;
+
+class PostResourceTest extends KernelTestCase
+{
+    private PostResource $postResource;
+
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+
+        $container = self::getContainer();
+        $this->postResource = $container->get(PostResource::class);
+        $this->entityManager = $container->get(EntityManagerInterface::class);
+    }
+
+    #[TestDox('DTO data is persisted when creating a post.')]
+    public function testCreateMapsDtoToEntity(): void
+    {
+        $blog = $this->createBlog('Integration blog create');
+        $tagA = $this->createTag('integration-tag-a');
+        $tagB = $this->createTag('integration-tag-b');
+
+        $dto = (new PostCreate())
+            ->setTitle('Integration post title')
+            ->setUrl('https://example.com/integration-post')
+            ->setSummary('Integration summary for post resource create test')
+            ->setContent(str_repeat('content ', 5))
+            ->setAuthor(Uuid::uuid4())
+            ->setBlog($blog)
+            ->setTags([$tagA, $tagB])
+            ->setPublishedAt('2024-01-01T10:00:00+00:00');
+
+        $post = $this->postResource->create($dto);
+
+        self::assertInstanceOf(Post::class, $post);
+        self::assertSame('Integration post title', $post->getTitle());
+        self::assertSame('https://example.com/integration-post', $post->getUrl());
+        self::assertSame('Integration summary for post resource create test', $post->getSummary());
+        self::assertSame(str_repeat('content ', 5), $post->getContent());
+        self::assertTrue($post->getTags()->contains($tagA));
+        self::assertTrue($post->getTags()->contains($tagB));
+        self::assertSame($blog->getId(), $post->getBlog()?->getId());
+    }
+
+    #[TestDox('Visited fields on the DTO patch update the existing post.')]
+    public function testPatchUpdatesOnlyVisitedFields(): void
+    {
+        $blog = $this->createBlog('Integration blog patch');
+        $initialTag = $this->createTag('integration-tag-initial');
+
+        $createDto = (new PostCreate())
+            ->setTitle('Patch me please')
+            ->setUrl('https://example.com/patch-me')
+            ->setSummary('Initial summary before patching')
+            ->setContent(str_repeat('initial ', 5))
+            ->setAuthor(Uuid::uuid4())
+            ->setBlog($blog)
+            ->setTags([$initialTag])
+            ->setPublishedAt('2024-02-02T12:00:00+00:00');
+
+        $post = $this->postResource->create($createDto);
+
+        $newTag = $this->createTag('integration-tag-updated');
+
+        $patchDto = (new PostPatch())
+            ->setSummary('Updated summary from patch test')
+            ->setContent(str_repeat('patched ', 4))
+            ->setTags([$newTag]);
+
+        $updated = $this->postResource->patch($post->getId(), $patchDto);
+
+        self::assertSame('Patch me please', $updated->getTitle());
+        self::assertSame('Updated summary from patch test', $updated->getSummary());
+        self::assertSame(str_repeat('patched ', 4), $updated->getContent());
+        self::assertTrue($updated->getTags()->contains($newTag));
+        self::assertFalse($updated->getTags()->contains($initialTag));
+    }
+
+    private function createBlog(string $title): Blog
+    {
+        $blog = new Blog();
+        $blog->setTitle($title);
+        $blog->setAuthor(Uuid::uuid4());
+        $blog->setBlogSubtitle(sprintf('%s subtitle', $title));
+
+        $this->entityManager->persist($blog);
+        $this->entityManager->flush();
+
+        return $blog;
+    }
+
+    private function createTag(string $name): Tag
+    {
+        $tag = new Tag($name);
+        $tag->setDescription(sprintf('%s description', $name));
+
+        $this->entityManager->persist($tag);
+        $this->entityManager->flush();
+
+        return $tag;
+    }
+}


### PR DESCRIPTION
## Summary
- align the post DTO with the domain entity by exposing title, URL, summary, content, author, blog, tags, media IDs and publication date fields with appropriate validation and mapping
- update the request mapper to normalise request aliases and hydrate blog and tag relations from identifiers
- add integration tests that exercise the post resource create and patch flows to verify DTO-to-entity synchronisation

## Testing
- attempted `composer install --no-interaction` *(fails: missing extensions)*
- attempted `composer install --no-interaction --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium` *(fails: GitHub 403 when downloading dependencies)*
- attempted `vendor/bin/phpunit tests/Application/Blog/Application/Resource/PostResourceTest.php` *(fails: binary unavailable before installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d310b351008326b8b4e420555a1e0e