### PR TITLE
Use repository interfaces in blog controllers

### DIFF
--- a/src/Blog/Domain/Repository/Interfaces/CommentRepositoryInterface.php
+++ b/src/Blog/Domain/Repository/Interfaces/CommentRepositoryInterface.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace App\Blog\Domain\Repository\Interfaces;
 
+use App\General\Domain\Repository\Interfaces\BaseRepositoryInterface;
+
 /**
  * @package App\Blog
  */
-interface CommentRepositoryInterface
+interface CommentRepositoryInterface extends BaseRepositoryInterface
 {
     /**
-     * @return array
+     * @return array<string, int>
      */
     public function countCommentsByMonth(): array;
 }

--- a/src/Blog/Domain/Repository/Interfaces/PostRepositoryInterface.php
+++ b/src/Blog/Domain/Repository/Interfaces/PostRepositoryInterface.php
@@ -4,13 +4,31 @@ declare(strict_types=1);
 
 namespace App\Blog\Domain\Repository\Interfaces;
 
+use App\Blog\Domain\Entity\Comment;
+use App\Blog\Domain\Entity\Post;
+use App\General\Domain\Repository\Interfaces\BaseRepositoryInterface;
+
 /**
  * @package App\Blog
  */
-interface PostRepositoryInterface
+interface PostRepositoryInterface extends BaseRepositoryInterface
 {
     /**
-     * @return array
+     * @return array<int, Post>
+     */
+    public function findWithRelations(int $limit, int $offset, ?string $authorId = null): array;
+
+    public function countPosts(?string $authorId = null): int;
+
+    /**
+     * @return array<int, Comment>
+     */
+    public function getRootComments(string $postId, int $limit, int $offset): array;
+
+    public function countComments(string $postId): int;
+
+    /**
+     * @return array<string, int>
      */
     public function countPostsByMonth(): array;
 }

--- a/src/Blog/Transport/Controller/Frontend/LoggedPostsController.php
+++ b/src/Blog/Transport/Controller/Frontend/LoggedPostsController.php
@@ -9,8 +9,8 @@ use App\Blog\Application\Service\CommentResponseHelper;
 use App\Blog\Domain\Entity\Media;
 use App\Blog\Application\Service\PostFeedResponseBuilder;
 use App\Blog\Domain\Entity\Comment;
-use App\Blog\Infrastructure\Repository\CommentRepository;
-use App\Blog\Infrastructure\Repository\PostRepository;
+use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;
+use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;
 use App\General\Infrastructure\ValueObject\SymfonyUser;
 use Doctrine\ORM\Exception\NotSupported;
 use Doctrine\ORM\Exception\ORMException;
@@ -45,8 +45,8 @@ readonly class LoggedPostsController
 {
     public function __construct(
         private TagAwareCacheInterface $cache,
-        private PostRepository $postRepository,
-        private CommentRepository $commentRepository,
+        private PostRepositoryInterface $postRepository,
+        private CommentRepositoryInterface $commentRepository,
         private UserProxy $userProxy,
         private CommentResponseHelper $commentResponseHelper,
         private PostFeedResponseBuilder $postFeedResponseBuilder
@@ -377,7 +377,7 @@ readonly class LoggedPostsController
     public function commentReactions(string $id): JsonResponse
     {
         /** @var Comment|null $comment */
-        $comment = $this->postRepository->getEntityManager()->getRepository(Comment::class)->find($id);
+        $comment = $this->commentRepository->find($id);
         if (!$comment) {
             return new JsonResponse(['error' => 'Comment not found'], 404);
         }

--- a/src/Blog/Transport/Controller/Frontend/PostsController.php
+++ b/src/Blog/Transport/Controller/Frontend/PostsController.php
@@ -8,8 +8,8 @@ use App\Blog\Application\ApiProxy\UserProxy;
 use App\Blog\Application\Service\CommentResponseHelper;
 use App\Blog\Application\Service\PostFeedResponseBuilder;
 use App\Blog\Domain\Entity\Comment;
-use App\Blog\Infrastructure\Repository\CommentRepository;
-use App\Blog\Infrastructure\Repository\PostRepository;
+use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;
+use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;
 use Doctrine\ORM\Exception\NotSupported;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\NonUniqueResultException;
@@ -41,8 +41,8 @@ readonly class PostsController
 {
     public function __construct(
         private TagAwareCacheInterface $cache,
-        private PostRepository $postRepository,
-        private CommentRepository $commentRepository,
+        private PostRepositoryInterface $postRepository,
+        private CommentRepositoryInterface $commentRepository,
         private UserProxy $userProxy,
         private CommentResponseHelper $commentResponseHelper,
         private PostFeedResponseBuilder $postFeedResponseBuilder,
@@ -257,7 +257,7 @@ readonly class PostsController
     public function commentReactions(string $id): JsonResponse
     {
         /** @var Comment|null $comment */
-        $comment = $this->postRepository->getEntityManager()->getRepository(Comment::class)->find($id);
+        $comment = $this->commentRepository->find($id);
         if (!$comment) {
             return new JsonResponse(['error' => 'Comment not found'], 404);
         }


### PR DESCRIPTION
## Summary
- expand the post repository interface with the methods used by the blog controllers and expose the base repository contract through inheritance
- extend the comment repository interface with the base repository contract for controller lookups
- inject the repository interfaces into the frontend controllers and reuse the comment repository for reaction lookups

## Testing
- make phpstan *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d31ea775448326b3aef9d1f877ece0