### PR TITLE
Invalidate posts cache on create

### DIFF
--- a/src/Blog/Transport/MessageHandler/CreatePostHandlerMessage.php
+++ b/src/Blog/Transport/MessageHandler/CreatePostHandlerMessage.php
@@ -16,7 +16,7 @@ use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
@@ -35,7 +35,7 @@ readonly class CreatePostHandlerMessage
 {
     public function __construct(
         private PostService $postService,
-        private CacheInterface $cache,
+        private TagAwareCacheInterface $cache,
         private PostRepositoryInterface $postRepository,
         private UserProxy $userProxy
     )
@@ -63,7 +63,12 @@ readonly class CreatePostHandlerMessage
     private function handleMessage(CreatePostMessenger $message): void
     {
         $this->postService->savePost($message->getPost(), $message->getMediasIds());
+
         $cacheKey = 'all_posts_' . 1 . '_' . 10;
+
+        $this->cache->invalidateTags(['posts']);
+        $this->cache->delete($cacheKey);
+
         $this->cache->get($cacheKey, fn (ItemInterface $item) => $this->getClosure(10, 1)($item));
     }
 
@@ -77,6 +82,10 @@ readonly class CreatePostHandlerMessage
     private function getClosure($limit, $offset): Closure
     {
         return function (ItemInterface $item) use($limit, $offset): array {
+            if (method_exists($item, 'tag')) {
+                $item->tag(['posts']);
+            }
+
             $item->expiresAfter(31536000);
 
             return $this->getFormattedPosts($limit, $offset);

--- a/tests/Application/Blog/Transport/Controller/PostsControllerCacheTest.php
+++ b/tests/Application/Blog/Transport/Controller/PostsControllerCacheTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Blog\Transport\Controller;
+
+use App\Blog\Application\ApiProxy\UserProxy;
+use App\Blog\Domain\Entity\Post;
+use App\Blog\Domain\Message\CreatePostMessenger;
+use App\Blog\Infrastructure\Repository\BlogRepository;
+use App\Blog\Transport\MessageHandler\CreatePostHandlerMessage;
+use App\Tests\TestCase\WebTestCase;
+use DateTimeImmutable;
+use JsonException;
+use Override;
+use PHPUnit\Framework\Attributes\TestDox;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+use function array_column;
+use function array_reduce;
+use function array_search;
+use function json_decode;
+use function sprintf;
+
+use const JSON_THROW_ON_ERROR;
+
+class PostsControllerCacheTest extends WebTestCase
+{
+    private KernelBrowser $client;
+
+    private TagAwareCacheInterface $cache;
+
+    private CreatePostHandlerMessage $handler;
+
+    private BlogRepository $blogRepository;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::ensureKernelShutdown();
+
+        $this->client = static::createClient();
+
+        $container = static::getContainer();
+        $this->overrideUserProxy($container);
+
+        $this->cache = $container->get(TagAwareCacheInterface::class);
+        $this->handler = $container->get(CreatePostHandlerMessage::class);
+        $this->blogRepository = $container->get(BlogRepository::class);
+    }
+
+    #[TestDox('Creating a post invalidates the posts cache so the listing endpoint returns it immediately.')]
+    public function testCreatePostInvalidatesPostsCache(): void
+    {
+        $limit = 10;
+        $cacheKey = 'all_posts_' . 1 . '_' . 10;
+
+        $this->cache->invalidateTags(['posts']);
+        $this->cache->delete($cacheKey);
+
+        $initialPayload = $this->requestPosts($limit);
+        self::assertArrayHasKey('data', $initialPayload);
+        self::assertNotEmpty($initialPayload['data']);
+
+        $newSlug = sprintf('cache-invalidation-%s', Uuid::uuid4()->toString());
+        self::assertNotContains($newSlug, array_column($initialPayload['data'], 'slug'));
+
+        $post = $this->createPost($newSlug);
+
+        ($this->handler)(new CreatePostMessenger($post, null));
+
+        $updatedPayload = $this->requestPosts($limit);
+
+        $slugs = array_column($updatedPayload['data'], 'slug');
+        self::assertContains($newSlug, $slugs);
+
+        $newIndex = array_search($newSlug, $slugs, true);
+        self::assertIsInt($newIndex);
+        self::assertSame(0, $newIndex, 'The newly created post should appear first in the feed.');
+    }
+
+    private function requestPosts(int $limit): array
+    {
+        $this->client->request('GET', '/public/post', ['limit' => $limit]);
+
+        $response = $this->client->getResponse();
+        self::assertInstanceOf(Response::class, $response);
+        self::assertTrue($response->isSuccessful());
+
+        try {
+            /** @var array{data: array<int, array<string, mixed>>} $payload */
+            $payload = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            self::fail('Failed to decode posts response: ' . $exception->getMessage());
+        }
+
+        return $payload;
+    }
+
+    private function createPost(string $slug): Post
+    {
+        $blog = $this->blogRepository->findOneBy([]);
+        self::assertNotNull($blog);
+
+        $post = new Post();
+        $post->setTitle('Cache invalidation post');
+        $post->setSlug($slug);
+        $post->setSummary('Post used to verify cache invalidation.');
+        $post->setContent('This post ensures the posts cache is refreshed immediately after creation.');
+        $post->setUrl(sprintf('https://example.com/%s', $slug));
+        $post->setAuthor($this->createAuthor());
+        $post->setBlog($blog);
+        $post->setPublishedAt(new DateTimeImmutable('+1 minute'));
+
+        return $post;
+    }
+
+    private function createAuthor(): UuidInterface
+    {
+        return Uuid::uuid4();
+    }
+
+    private function overrideUserProxy(ContainerInterface $container): void
+    {
+        $userProxy = $this->createMock(UserProxy::class);
+
+        $userProxy->method('searchUser')->willReturnCallback(
+            static fn(string $id): array => [
+                'id' => $id,
+                'username' => 'user_' . $id,
+            ],
+        );
+
+        $userProxy->method('batchSearchUsers')->willReturnCallback(
+            static fn(array $ids): array => array_reduce(
+                $ids,
+                static function (array $carry, string $id): array {
+                    $carry[$id] = [
+                        'id' => $id,
+                        'username' => 'user_' . $id,
+                    ];
+
+                    return $carry;
+                },
+                [],
+            ),
+        );
+
+        $userProxy->method('getMedia')->willReturnCallback(
+            static fn(string $id): array => [
+                'id' => $id,
+                'url' => 'https://media.example/' . $id,
+            ],
+        );
+
+        $container->set(UserProxy::class, $userProxy);
+        $container->set('App\\Blog\\Application\\ApiProxy\\UserProxy', $userProxy);
+    }
+}
+


### PR DESCRIPTION
## Summary
- switch the CreatePost message handler to the tag-aware cache and clear the posts tag before warming the list cache
- ensure cached post collections receive the posts tag
- add a functional test that creates a post and verifies the public listing reflects it immediately

## Testing
- not run (composer install failed: GitHub 403 when downloading dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68d31f214034832699789e51e429dda1