### PR TITLE
Simplify JSON responses in blog controllers

### DIFF
--- a/src/Blog/Transport/Controller/Frontend/Blog/BlogController.php
+++ b/src/Blog/Transport/Controller/Frontend/Blog/BlogController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Frontend\Blog;
 
 use App\Blog\Domain\Repository\Interfaces\BlogRepositoryInterface;
-use App\General\Domain\Utils\JSON;
 use Closure;
 use Doctrine\ORM\Exception\NotSupported;
 use Exception;
@@ -50,17 +49,15 @@ readonly class BlogController
     {
         $cacheKey = 'public_blog';
         $blogs = $this->cache->get($cacheKey, fn (ItemInterface $item) => $this->getClosure()($item));
-        $output = JSON::decode(
-            $this->serializer->serialize(
-                $blogs,
-                'json',
-                [
-                    'groups' => 'Blog',
-                ]
-            ),
-            true,
+        $json = $this->serializer->serialize(
+            $blogs,
+            'json',
+            [
+                'groups' => 'Blog',
+            ]
         );
-        return new JsonResponse($output);
+
+        return JsonResponse::fromJsonString($json);
     }
 
     /**

--- a/src/Blog/Transport/Controller/Frontend/Blog/UpdateBlogTeamsController.php
+++ b/src/Blog/Transport/Controller/Frontend/Blog/UpdateBlogTeamsController.php
@@ -6,7 +6,6 @@ namespace App\Blog\Transport\Controller\Frontend\Blog;
 
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Repository\Interfaces\BlogRepositoryInterface;
-use App\General\Domain\Utils\JSON;
 use App\General\Infrastructure\ValueObject\SymfonyUser;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
@@ -68,16 +67,14 @@ readonly class UpdateBlogTeamsController
 
         $this->blogRepository->save($blog);
 
-        $output = JSON::decode(
-            $this->serializer->serialize(
-                $blog,
-                'json',
-                [
-                    'groups' => 'BlogProfile',
-                ]
-            ),
-            true,
+        $json = $this->serializer->serialize(
+            $blog,
+            'json',
+            [
+                'groups' => 'BlogProfile',
+            ]
         );
-        return new JsonResponse($output);
+
+        return JsonResponse::fromJsonString($json);
     }
 }

--- a/src/Blog/Transport/Controller/Frontend/Blog/UserBlogController.php
+++ b/src/Blog/Transport/Controller/Frontend/Blog/UserBlogController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Frontend\Blog;
 
 use App\Blog\Domain\Repository\Interfaces\BlogRepositoryInterface;
-use App\General\Domain\Utils\JSON;
 use App\General\Infrastructure\ValueObject\SymfonyUser;
 use Closure;
 use Doctrine\ORM\Exception\NotSupported;
@@ -54,17 +53,15 @@ readonly class UserBlogController
     {
         $cacheKey = 'profile_blog_' . $symfonyUser->getUserIdentifier();
         $blogs = $this->cache->get($cacheKey, fn (ItemInterface $item) => $this->getClosure($symfonyUser->getUserIdentifier())($item));
-        $output = JSON::decode(
-            $this->serializer->serialize(
-                $blogs,
-                'json',
-                [
-                    'groups' => 'BlogProfile',
-                ]
-            ),
-            true,
+        $json = $this->serializer->serialize(
+            $blogs,
+            'json',
+            [
+                'groups' => 'BlogProfile',
+            ]
         );
-        return new JsonResponse($output);
+
+        return JsonResponse::fromJsonString($json);
     }
 
     /**

--- a/src/Blog/Transport/Controller/Frontend/Comment/CommentsController.php
+++ b/src/Blog/Transport/Controller/Frontend/Comment/CommentsController.php
@@ -6,7 +6,6 @@ namespace App\Blog\Transport\Controller\Frontend\Comment;
 
 use App\Blog\Application\ApiProxy\UserProxy;
 use App\Blog\Domain\Entity\Post;
-use App\General\Domain\Utils\JSON;
 use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -66,17 +65,15 @@ readonly class CommentsController
         foreach ($rootComments as $comment) {
             $commentData[] = $this->formatCommentRecursively($comment, $usersById);
         }
-        $output = JSON::decode(
-            $this->serializer->serialize(
-                $commentData,
-                'json',
-                [
-                    'groups' => 'Comment',
-                ]
-            ),
-            true,
+        $json = $this->serializer->serialize(
+            $commentData,
+            'json',
+            [
+                'groups' => 'Comment',
+            ]
         );
-        return new JsonResponse($output);
+
+        return JsonResponse::fromJsonString($json);
     }
 
     /**

--- a/src/Blog/Transport/Controller/Frontend/Comment/CreateCommentController.php
+++ b/src/Blog/Transport/Controller/Frontend/Comment/CreateCommentController.php
@@ -7,7 +7,6 @@ namespace App\Blog\Transport\Controller\Frontend\Comment;
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Entity\Post;
 use App\Blog\Domain\Message\CreateCommentMessenger;
-use App\General\Domain\Utils\JSON;
 use App\General\Infrastructure\ValueObject\SymfonyUser;
 use JsonException;
 use OpenApi\Attributes as OA;
@@ -64,16 +63,14 @@ readonly class CreateCommentController
             )
         );
 
-        $output = JSON::decode(
-            $this->serializer->serialize(
-                $comment,
-                'json',
-                [
-                    'groups' => 'Comment',
-                ]
-            ),
-            true,
+        $json = $this->serializer->serialize(
+            $comment,
+            'json',
+            [
+                'groups' => 'Comment',
+            ]
         );
-        return new JsonResponse($output);
+
+        return JsonResponse::fromJsonString($json);
     }
 }

--- a/src/Blog/Transport/Controller/Frontend/Post/PostController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/PostController.php
@@ -8,7 +8,6 @@ use App\Blog\Application\ApiProxy\UserProxy;
 use App\Blog\Domain\Entity\Media;
 use App\Blog\Domain\Entity\Post;
 use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;
-use App\General\Domain\Utils\JSON;
 use Closure;
 use Doctrine\ORM\Exception\NotSupported;
 use JsonException;
@@ -58,17 +57,15 @@ readonly class PostController
     {
         $cacheKey = 'public_post_' . $slug;
         $blogs = $this->cache->get($cacheKey, fn (ItemInterface $item) => $this->getClosure($slug)($item));
-        $output = JSON::decode(
-            $this->serializer->serialize(
-                $blogs,
-                'json',
-                [
-                    'groups' => 'Post',
-                ]
-            ),
-            true,
+        $json = $this->serializer->serialize(
+            $blogs,
+            'json',
+            [
+                'groups' => 'Post',
+            ]
         );
-        return new JsonResponse($output);
+
+        return JsonResponse::fromJsonString($json);
     }
 
     /**


### PR DESCRIPTION
## Summary
- replace JSON::decode/JsonResponse constructions with JsonResponse::fromJsonString for blog/post/comment controllers
- remove unused JSON utility imports

## Testing
- make phpunit *(fails: docker not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3294f8aec832695271e3cce201383