### PR TITLE
Optimize user fetching for comments

### DIFF
--- a/src/Blog/Transport/Controller/Frontend/Comment/CommentsController.php
+++ b/src/Blog/Transport/Controller/Frontend/Comment/CommentsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Frontend\Comment;
 
 use App\Blog\Application\ApiProxy\UserProxy;
+use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Entity\Post;
 use App\General\Domain\Utils\JSON;
 use JsonException;
@@ -51,17 +52,22 @@ readonly class CommentsController
     #[Route(path: '/v1/platform/post/{post}/comments', name: 'platform_post_comments', methods: [Request::METHOD_GET])]
     public function __invoke(Post $post): JsonResponse
     {
-        $users = $this->userProxy->getUsers();
-
-        $usersById = [];
-        foreach ($users as $user) {
-            $usersById[$user['id']] = $user;
-        }
         $commentData = [];
         $rootComments = array_filter(
             $post->getComments()->toArray(),
             static fn($comment) => $comment->getParent() === null
         );
+
+        $userIds = [];
+        foreach ($rootComments as $comment) {
+            $this->collectCommentUserIds($comment, $userIds);
+        }
+
+        $usersById = [];
+        if ($userIds !== []) {
+            $users = $this->userProxy->batchSearchUsers(array_values(array_unique($userIds)));
+            $usersById = array_column($users, null, 'id');
+        }
 
         foreach ($rootComments as $comment) {
             $commentData[] = $this->formatCommentRecursively($comment, $usersById);
@@ -85,23 +91,46 @@ readonly class CommentsController
      *
      * @return array
      */
-    private function formatCommentRecursively($comment, array $usersById): array
+    private function formatCommentRecursively(Comment $comment, array $usersById): array
     {
         $authorId = $comment->getAuthor()->toString();
 
         $formatted = [
             'id' => $comment->getId(),
             'content' => $comment->getContent(),
-            'likes' => $comment->getLikes(),
+            'likes' => [],
             'publishedAt' => $comment->getPublishedAt()?->format(DATE_ATOM),
             'user' => $usersById[$authorId] ?? null,
             'children' => [],
         ];
+
+        foreach ($comment->getLikes() as $like) {
+            $likeUserId = $like->getUser()->toString();
+            $formatted['likes'][] = [
+                'id' => $like->getId(),
+                'user' => $usersById[$likeUserId] ?? null,
+            ];
+        }
 
         foreach ($comment->getChildren() as $child) {
             $formatted['children'][] = $this->formatCommentRecursively($child, $usersById);
         }
 
         return $formatted;
+    }
+
+    private function collectCommentUserIds(Comment $comment, array &$userIds): void
+    {
+        $userIds[] = $comment->getAuthor()->toString();
+
+        foreach ($comment->getLikes() as $like) {
+            $userIds[] = $like->getUser()->toString();
+        }
+
+        foreach ($comment->getChildren() as $child) {
+            if ($child instanceof Comment) {
+                $this->collectCommentUserIds($child, $userIds);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- collect author and like user identifiers from the comment tree and batch load user details
- reuse the preloaded user map when formatting comments and include like user data

## Testing
- php -l src/Blog/Transport/Controller/Frontend/Comment/CommentsController.php
- composer install --no-interaction *(fails: missing ext-amqp and ext-sodium)*
- composer install --no-interaction --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium *(fails: repeated 403 responses when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d3295768288326802f94a0464f344d