### PR TITLE
Fix user proxy lookup for numeric API payloads

### DIFF
--- a/src/Blog/Application/ApiProxy/UserProxy.php
+++ b/src/Blog/Application/ApiProxy/UserProxy.php
@@ -77,10 +77,19 @@ readonly class UserProxy
 
         $users = $this->getUsers();
         foreach ($users as $user) {
-            $this->userCacheService->save($user['id'], $user); // Ajoute tous les users au cache
+            if (!isset($user['id'])) {
+                continue;
+            }
+
+            $userId = (string) $user['id'];
+            $this->userCacheService->save($userId, $user); // Ajoute tous les users au cache
+
+            if ($userId === $id) {
+                return $user;
+            }
         }
 
-        return $users[$id] ?? null;
+        return null;
     }
 
     /**

--- a/tests/Unit/Blog/Application/ApiProxy/UserProxyTest.php
+++ b/tests/Unit/Blog/Application/ApiProxy/UserProxyTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Blog\Application\ApiProxy;
+
+use App\Blog\Application\ApiProxy\UserProxy;
+use App\Blog\Application\Service\UserCacheService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class UserProxyTest extends TestCase
+{
+    public function testSearchUserHandlesNumericallyIndexedPayload(): void
+    {
+        $users = [
+            ['id' => '10', 'name' => 'Alice'],
+            ['id' => '20', 'name' => 'Bob'],
+        ];
+
+        $httpClient = new MockHttpClient(new MockResponse(json_encode($users)));
+
+        $userCacheService = $this->createMock(UserCacheService::class);
+        $userCacheService->expects($this->once())
+            ->method('searchUser')
+            ->with('20')
+            ->willReturn(null);
+
+        $userCacheService->expects($this->exactly(2))
+            ->method('save')
+            ->withConsecutive(
+                ['10', $users[0]],
+                ['20', $users[1]]
+            );
+
+        $proxy = new UserProxy($httpClient, $userCacheService);
+
+        $result = $proxy->searchUser('20');
+
+        $this->assertSame($users[1], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- iterate through the external API payload in `UserProxy::searchUser` to match by ID while caching each fetched user
- add a unit test covering numerically indexed payloads to confirm the correct user is returned and caching occurs

## Testing
- ✅ `php -l src/Blog/Application/ApiProxy/UserProxy.php`
- ✅ `php -l tests/Unit/Blog/Application/ApiProxy/UserProxyTest.php`
- ⚠️ `composer install --no-interaction --no-progress --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium` *(fails because GitHub downloads are blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d32d31ff0c83269f65ec5aca5037c3