### PR TITLE
Add comment notification translations

### DIFF
--- a/translations/messages.en.yaml
+++ b/translations/messages.en.yaml
@@ -1,0 +1,2 @@
+notification.comment_created: 'New comment on your post'
+notification.comment_created.description: 'A new comment was added to your post "%title%". <a href="%link%">View comment</a>.'

--- a/translations/messages.ru.yaml
+++ b/translations/messages.ru.yaml
@@ -1,0 +1,2 @@
+notification.comment_created: 'Новый комментарий к вашей записи'
+notification.comment_created.description: 'К вашей записи «%title%» оставили новый комментарий. <a href="%link%">Просмотреть комментарий</a>.'

--- a/translations/messages.ua.yaml
+++ b/translations/messages.ua.yaml
@@ -1,0 +1,2 @@
+notification.comment_created: 'Новий коментар до вашого допису'
+notification.comment_created.description: 'До вашого допису «%title%» залишили новий коментар. <a href="%link%">Переглянути коментар</a>.'


### PR DESCRIPTION
## Summary
- add localized subject and body strings for comment notifications in the messages domain for English, Russian, and Ukrainian

## Testing
- bin/console cache:clear *(fails: missing composer dependencies and PHP extensions in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d32e22fd3c8326b836c570218e0eb7