### PR TITLE
Remove legacy crypt translations

### DIFF
--- a/translations/crypt.en.yaml
+++ b/translations/crypt.en.yaml
@@ -1,7 +1,0 @@
-OS does not support crypt algorithm: OS does not support crypt algorithm.
-Missing or wrong data for decrypt: Missing or wrong data for decrypt.
-Can not generate ivLen param for crypt: Can not generate ivLen param for crypt.
-Can not generate iv param for crypt: Can not generate iv param for crypt.
-Can not encrypt data: Can not encrypt data.
-Can not convert iv or tag param for decrypt: Can not convert iv or tag param for decrypt.
-Can not decrypt data: Can not decrypt data.

--- a/translations/crypt.ru.yaml
+++ b/translations/crypt.ru.yaml
@@ -1,7 +1,0 @@
-OS does not support crypt algorithm: OS не поддерживает алгоритм шифрования.
-Missing or wrong data for decrypt: Отсутствуют или неверные данные для расшифровки.
-Can not generate ivLen param for crypt: Невозможно сгенерировать ivLen параметр для шифрования.
-Can not generate iv param for crypt: Невозможно сгенерировать iv параметр для шифрования.
-Can not encrypt data: Невозможно зашифровать данные.
-Can not convert iv or tag param for decrypt: Невозможно конвертировать iv или tag параметр для расшифровки.
-Can not decrypt data: Невозможно расшифровать данные.

--- a/translations/crypt.ua.yaml
+++ b/translations/crypt.ua.yaml
@@ -1,7 +1,0 @@
-OS does not support crypt algorithm: OS не підтримує алгоритм шифрування.
-Missing or wrong data for decrypt: Відсутні або невірні дані для розшифрування.
-Can not generate ivLen param for crypt: Неможливо згенерувати ivLen параметр для шифрування.
-Can not generate iv param for crypt: Неможливо згенерувати iv параметр для шифрування.
-Can not encrypt data: Неможливо зашифрувати дані.
-Can not convert iv or tag param for decrypt: Неможливо конвертувати iv або tag параметр для розшифрування.
-Can not decrypt data: Неможливо розшифрувати дані.


### PR DESCRIPTION
## Summary
- remove unused crypt translation files now that the service is gone
- confirm there are no remaining references to the crypt service in src code

## Testing
- bin/console lint:translations *(fails: missing composer dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d32e25211c8326b7ca330d9da4933d