### PR TITLE
Translate French blog comments to English

### DIFF
--- a/src/Blog/Application/ApiProxy/UserProxy.php
+++ b/src/Blog/Application/ApiProxy/UserProxy.php
@@ -29,7 +29,7 @@ readonly class UserProxy
     ) {}
 
     /**
-     * Récupère tous les utilisateurs depuis l'API externe.
+     * Retrieves all users from the external API.
      *
      * @throws TransportExceptionInterface
      * @throws ServerExceptionInterface
@@ -49,7 +49,7 @@ readonly class UserProxy
     }
 
     /**
-     * Recherche des utilisateurs depuis le cache avec un mot-clé.
+     * Searches cached users with a keyword.
      *
      * @throws InvalidArgumentException
      */
@@ -59,7 +59,7 @@ readonly class UserProxy
     }
 
     /**
-     * Recherche un utilisateur spécifique par son ID.
+     * Looks up a specific user by ID.
      *
      * @throws InvalidArgumentException
      * @throws ClientExceptionInterface
@@ -82,7 +82,7 @@ readonly class UserProxy
             }
 
             $userId = (string) $user['id'];
-            $this->userCacheService->save($userId, $user); // Ajoute tous les users au cache
+            $this->userCacheService->save($userId, $user); // Adds every user to the cache.
 
             if ($userId === $id) {
                 return $user;
@@ -93,7 +93,7 @@ readonly class UserProxy
     }
 
     /**
-     * Recherche des médias (fallback méthode, potentiellement inutile ici).
+     * Searches media as a fallback method (likely unnecessary here).
      *
      * @throws InvalidArgumentException
      */
@@ -103,8 +103,7 @@ readonly class UserProxy
     }
 
     /**
-     * Récupère plusieurs utilisateurs à partir d'une liste d'IDs.
-     * Mise en cache avec tag 'users' pour chaque nouvel utilisateur.
+     * Retrieves several users by ID list and caches them with the "users" tag.
      *
      * @param string[] $ids
      * @return array<string, array> [userId => userData]
@@ -127,7 +126,7 @@ readonly class UserProxy
             foreach ($allUsers as $user) {
                 if (in_array($user['id'], $missing, true)) {
                     $usersData[$user['id']] = $user;
-                    // ✅ stockage avec tag 'users'
+                    // Stores the user with the "users" tag.
                     $this->userCacheService->save($user['id'], $user);
                 }
             }
@@ -137,7 +136,7 @@ readonly class UserProxy
     }
 
     /**
-     * Récupère les informations d’un média via son ID.
+     * Retrieves media details by its ID.
      *
      * @throws ClientExceptionInterface
      * @throws DecodingExceptionInterface

--- a/src/Blog/Application/Service/UserCacheService.php
+++ b/src/Blog/Application/Service/UserCacheService.php
@@ -65,7 +65,7 @@ readonly class UserCacheService implements UserCacheServiceInterface
     }
 
     /**
-     * Sauvegarde un utilisateur manuellement dans le cache, avec un tag "users".
+     * Manually stores a user in cache and tags it with "users".
      *
      * @param string $id
      * @param array $user
@@ -80,7 +80,7 @@ readonly class UserCacheService implements UserCacheServiceInterface
         $this->userCache->get($cacheKey, function (ItemInterface $item) use ($user, $ttl) {
             $item->expiresAfter($ttl);
 
-            // ✅ Ajoute le tag 'users' si le cache le permet
+            // Adds the "users" tag when supported by the cache item.
             if (method_exists($item, 'tag')) {
                 $item->tag(['users']);
             }

--- a/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
+++ b/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
@@ -108,7 +108,7 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
             $post->addTag(...$tags);
             $post->setBlog($blogGeneral);
 
-            // ✅ Ajout des commentaires
+            // Adds comments.
             foreach (range(1, random_int(1, 8)) as $i) {
                 $comment = new Comment();
                 $comment->setAuthor(Uuid::fromString('20000000-0000-1000-8000-00000000000' . random_int(1, 6)));
@@ -117,7 +117,7 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
                 $post->addComment($comment);
                 $manager->persist($comment);
 
-                // ✅ Ajout de likes sur les commentaires
+                // Adds likes to comments.
                 foreach (range(1, random_int(1, 4)) as $_) {
                     $like = new Like();
                     $like->setUser(Uuid::fromString('20000000-0000-1000-8000-00000000000' . random_int(1, 6)));
@@ -125,11 +125,11 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
                     $manager->persist($like);
                 }
 
-                // ✅ Ajout de réactions sur les commentaires
+                // Adds reactions to comments.
                 $this->addRandomReactions($manager, null, $comment);
             }
 
-            // ✅ Ajout de likes sur les posts
+            // Adds likes to posts.
             foreach (range(1, random_int(1, 6)) as $_) {
                 $like = new Like();
                 $like->setUser(Uuid::fromString('20000000-0000-1000-8000-00000000000' . random_int(1, 6)));
@@ -137,7 +137,7 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
                 $manager->persist($like);
             }
 
-            // ✅ Ajout de réactions sur les posts
+            // Adds reactions to posts.
             $this->addRandomReactions($manager, $post, null);
 
             $manager->persist($post);
@@ -164,7 +164,7 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
     {
         $posts = [];
 
-        // ✅ Ajout de titres faker en plus
+        // Adds additional Faker-generated titles.
         $titles = array_merge($this->getPhrases(), $this->generateFakerTitles(290));
 
         foreach ($titles as $i => $title) {
@@ -228,7 +228,7 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
     }
 
     /**
-     * ✅ Ajoute des réactions aléatoires pour un post ou un commentaire
+     * Adds random reactions for a post or a comment.
      *
      * @param ObjectManager $manager
      * @param Post|null     $post
@@ -238,11 +238,11 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
      */
     private function addRandomReactions(ObjectManager $manager, ?Post $post = null, ?Comment $comment = null): void
     {
-        $usedUsers = []; // ✅ pour éviter les doublons user+post/comment
+        $usedUsers = []; // Prevent duplicate user-to-post or user-to-comment combinations.
         $maxReactions = random_int(1, 6);
 
         foreach (range(1, $maxReactions) as $_) {
-            // Générer un user unique pour ce post/comment
+            // Generate a unique user for this post or comment.
             do {
                 $userUuid = '20000000-0000-1000-8000-00000000000' . random_int(1, 6);
             } while (in_array($userUuid, $usedUsers, true));

--- a/src/Blog/Infrastructure/Repository/PostRepository.php
+++ b/src/Blog/Infrastructure/Repository/PostRepository.php
@@ -86,7 +86,8 @@ class PostRepository extends BaseRepository implements PostRepositoryInterface
         return $qb->getQuery()->getResult();
     }
 
-    /** Compte les posts (optionnellement par auteur)
+    /**
+     * Counts posts, optionally filtered by author.
      *
      * @param string|null $authorId
      *
@@ -117,7 +118,7 @@ class PostRepository extends BaseRepository implements PostRepositoryInterface
             ->join('c.post', 'p')
             ->where('p.id = :postId')
             ->andWhere('c.parent IS NULL')
-            ->setParameter('postId', Uuid::fromString($postId), 'uuid_binary_ordered_time') // ✅ conversion
+            ->setParameter('postId', Uuid::fromString($postId), 'uuid_binary_ordered_time') // Converts the ID to the UUID binary format.
             ->orderBy('c.publishedAt', 'DESC')
             ->setMaxResults($limit)
             ->setFirstResult($offset)
@@ -140,7 +141,7 @@ class PostRepository extends BaseRepository implements PostRepositoryInterface
             ->join('c.post', 'p')
             ->where('p.id = :postId')
             ->andWhere('c.parent IS NULL')
-            ->setParameter('postId', Uuid::fromString($postId), 'uuid_binary_ordered_time') // ✅ conversion UUID
+            ->setParameter('postId', Uuid::fromString($postId), 'uuid_binary_ordered_time') // Converts the ID to the UUID binary format.
             ->getQuery()
             ->getSingleScalarResult();
     }

--- a/src/Blog/Transport/Controller/Frontend/Post/LoggedPostsController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/LoggedPostsController.php
@@ -84,7 +84,8 @@ readonly class LoggedPostsController
         return new JsonResponse($result);
     }
 
-    /** ✅ Endpoint lazy load commentaires (avec `isLiked` et `reactions_count`)
+    /**
+     * Lazy-load endpoint for comments (includes `isLiked` and `reactions_count`).
      *
      * @param string      $id
      * @param SymfonyUser $symfonyUser
@@ -134,7 +135,8 @@ readonly class LoggedPostsController
         return new JsonResponse(['comments' => $data, 'total' => $total, 'page' => $page]);
     }
 
-    /** ✅ Endpoint lazy load likes d’un post
+    /**
+     * Lazy-load endpoint for a post's likes.
      *
      * @param string $id
      *
@@ -175,7 +177,8 @@ readonly class LoggedPostsController
         ]);
     }
 
-    /** ✅ Endpoint lazy load likes d’un post
+    /**
+     * Lazy-load endpoint for a comment's likes.
      *
      * @param string $id
      *
@@ -216,7 +219,8 @@ readonly class LoggedPostsController
         ]);
     }
 
-    /** ✅ Endpoint lazy load reactions d’un post
+    /**
+     * Lazy-load endpoint for a post's reactions.
      *
      * @param string $id
      *
@@ -248,7 +252,8 @@ readonly class LoggedPostsController
         ]);
     }
 
-    /** ✅ Nouveau : Endpoint reactions d’un commentaire
+    /**
+     * Lazy-load endpoint for a comment's reactions.
      *
      * @param string $id
      *

--- a/src/Blog/Transport/Controller/Frontend/Post/MyPostsController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/MyPostsController.php
@@ -193,7 +193,8 @@ readonly class MyPostsController
      *
      * @return string|null
      */
-    /** ✅ Endpoint lazy load commentaires (avec `isLiked` et `reactions_count`)
+    /**
+     * Lazy-load endpoint for comments (includes `isLiked` and `reactions_count`).
      *
      * @param string      $id
      * @param SymfonyUser $symfonyUser
@@ -242,7 +243,8 @@ readonly class MyPostsController
         return new JsonResponse(['comments' => $data, 'total' => $total, 'page' => $page]);
     }
 
-    /** ✅ Endpoint lazy load likes d’un post
+    /**
+     * Lazy-load endpoint for a post's likes.
      *
      * @param string $id
      *
@@ -283,7 +285,8 @@ readonly class MyPostsController
         ]);
     }
 
-    /** ✅ Endpoint lazy load likes d’un post
+    /**
+     * Lazy-load endpoint for a comment's likes.
      *
      * @param string $id
      *
@@ -324,7 +327,8 @@ readonly class MyPostsController
         ]);
     }
 
-    /** ✅ Endpoint lazy load reactions d’un post
+    /**
+     * Lazy-load endpoint for a post's reactions.
      *
      * @param string $id
      *
@@ -356,7 +360,8 @@ readonly class MyPostsController
         ]);
     }
 
-    /** ✅ Nouveau : Endpoint reactions d’un commentaire
+    /**
+     * Lazy-load endpoint for a comment's reactions.
      *
      * @param string $id
      *

--- a/src/Blog/Transport/Controller/Frontend/Post/PostsController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/PostsController.php
@@ -76,7 +76,8 @@ readonly class PostsController
         return new JsonResponse($result);
     }
 
-    /** ✅ Endpoint lazy load commentaires (avec `isLiked` et `reactions_count`)
+    /**
+     * Lazy-load endpoint for comments (includes `isLiked` and `reactions_count`).
      *
      * @param string      $id
      * @param Request     $request
@@ -126,7 +127,8 @@ readonly class PostsController
         return new JsonResponse(['comments' => $data, 'total' => $total, 'page' => $page]);
     }
 
-    /** ✅ Endpoint lazy load likes d’un post
+    /**
+     * Lazy-load endpoint for a post's likes.
      *
      * @param string $id
      *
@@ -167,7 +169,8 @@ readonly class PostsController
         ]);
     }
 
-    /** ✅ Endpoint lazy load likes d’un post
+    /**
+     * Lazy-load endpoint for a comment's likes.
      *
      * @param string $id
      *
@@ -208,7 +211,8 @@ readonly class PostsController
         ]);
     }
 
-    /** ✅ Endpoint lazy load reactions d’un post
+    /**
+     * Lazy-load endpoint for a post's reactions.
      *
      * @param string $id
      *
@@ -240,7 +244,8 @@ readonly class PostsController
         ]);
     }
 
-    /** ✅ Nouveau : Endpoint reactions d’un commentaire
+    /**
+     * Lazy-load endpoint for a comment's reactions.
      *
      * @param string $id
      *


### PR DESCRIPTION
## Summary
- replace French documentation comments across blog user proxy, cache service, controllers, fixtures, and repository with English equivalents
- update inline cache and reaction notes to English sentences that follow the project's comment style

## Testing
- make ecs *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d333e6930c8326aa9200be226dc07b