### PR TITLE
Add blog edit and delete endpoints with tests

### DIFF
--- a/src/Blog/Transport/Controller/Frontend/Blog/DeleteBlogController.php
+++ b/src/Blog/Transport/Controller/Frontend/Blog/DeleteBlogController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Transport\Controller\Frontend\Blog;
+
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Repository\Interfaces\BlogRepositoryInterface;
+use App\General\Infrastructure\ValueObject\SymfonyUser;
+use OpenApi\Attributes as OA;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * @package App\Blog
+ */
+#[AsController]
+#[OA\Tag(name: 'Blog')]
+readonly class DeleteBlogController
+{
+    public function __construct(
+        private BlogRepositoryInterface $blogRepository,
+        private CacheItemPoolInterface $cacheItemPool,
+        private CacheInterface $cacheInterface,
+    ) {
+    }
+
+    /**
+     * Remove an existing blog owned by the authenticated user.
+     *
+     * @throws InvalidArgumentException
+     */
+    #[Route(path: '/v1/platform/blog/{blog}', name: 'blog_delete', methods: [Request::METHOD_DELETE])]
+    public function __invoke(SymfonyUser $symfonyUser, Blog $blog): JsonResponse
+    {
+        if ($blog->getAuthor()->toString() !== $symfonyUser->getUserIdentifier()) {
+            return new JsonResponse(['error' => 'Access denied.'], Response::HTTP_FORBIDDEN);
+        }
+
+        $authorId = $symfonyUser->getUserIdentifier();
+        $slug = $blog->getSlug();
+
+        $this->blogRepository->remove($blog);
+
+        $this->cacheItemPool->deleteItem('profile_blog_' . $authorId);
+        $this->cacheInterface->delete('public_blog');
+
+        if ($slug !== null) {
+            $this->cacheInterface->delete('private_blog_' . $slug);
+        }
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Blog/Transport/Controller/Frontend/Blog/EditBlogController.php
+++ b/src/Blog/Transport/Controller/Frontend/Blog/EditBlogController.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Transport\Controller\Frontend\Blog;
+
+use App\Blog\Application\Service\BlogService;
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Repository\Interfaces\BlogRepositoryInterface;
+use App\General\Infrastructure\ValueObject\SymfonyUser;
+use OpenApi\Attributes as OA;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Cache\CacheInterface;
+use Throwable;
+
+use function array_key_exists;
+use function is_array;
+use function is_string;
+use function json_decode;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * @package App\Blog
+ */
+#[AsController]
+#[OA\Tag(name: 'Blog')]
+readonly class EditBlogController
+{
+    public function __construct(
+        private BlogService $blogService,
+        private BlogRepositoryInterface $blogRepository,
+        private CacheItemPoolInterface $cacheItemPool,
+        private CacheInterface $cacheInterface,
+    ) {
+    }
+
+    /**
+     * Update an existing blog for the authenticated owner.
+     *
+     * @throws InvalidArgumentException
+     */
+    #[Route(
+        path: '/v1/platform/blog/{blog}',
+        name: 'blog_edit',
+        methods: [Request::METHOD_PUT, Request::METHOD_PATCH]
+    )]
+    public function __invoke(SymfonyUser $symfonyUser, Request $request, Blog $blog): JsonResponse
+    {
+        if ($blog->getAuthor()->toString() !== $symfonyUser->getUserIdentifier()) {
+            return new JsonResponse(['error' => 'Access denied.'], Response::HTTP_FORBIDDEN);
+        }
+
+        $payload = $this->extractPayload($request);
+
+        if (array_key_exists('title', $payload) && is_string($payload['title'])) {
+            $blog->setTitle($payload['title']);
+        }
+
+        if (array_key_exists('description', $payload)) {
+            $blog->setBlogSubtitle($this->normalizeNullableString($payload['description']));
+        } elseif (array_key_exists('subtitle', $payload)) {
+            $blog->setBlogSubtitle($this->normalizeNullableString($payload['subtitle']));
+        }
+
+        $files = $request->files->get('files');
+        if ($files) {
+            $logo = $this->blogService->uploadLogo($request);
+            if ($logo instanceof JsonResponse) {
+                return $logo;
+            }
+
+            $blog->setLogo($logo);
+        }
+
+        $previousSlug = $blog->getSlug();
+
+        $this->blogRepository->save($blog);
+
+        $this->cacheItemPool->deleteItem('profile_blog_' . $symfonyUser->getUserIdentifier());
+        $this->cacheInterface->delete('public_blog');
+
+        if ($previousSlug !== null) {
+            $this->cacheInterface->delete('private_blog_' . $previousSlug);
+        }
+
+        $newSlug = $blog->getSlug();
+        if ($newSlug !== null) {
+            $this->cacheInterface->delete('private_blog_' . $newSlug);
+        }
+
+        return new JsonResponse([
+            'id' => $blog->getId(),
+            'title' => $blog->getTitle(),
+            'description' => $blog->getBlogSubtitle(),
+            'slug' => $blog->getSlug(),
+            'logo' => $blog->getLogo(),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function extractPayload(Request $request): array
+    {
+        $data = $request->request->all();
+
+        if ($data !== []) {
+            return $data;
+        }
+
+        $content = $request->getContent();
+        if ($content === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            return [];
+        }
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function normalizeNullableString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return is_string($value) ? $value : null;
+    }
+}

--- a/tests/Application/Blog/Transport/Controller/Frontend/DeleteBlogControllerTest.php
+++ b/tests/Application/Blog/Transport/Controller/Frontend/DeleteBlogControllerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Blog\Transport\Controller\Frontend;
+
+use App\Blog\Domain\Entity\Blog;
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+use function uniqid;
+
+final class DeleteBlogControllerTest extends WebTestCase
+{
+    private const string BASE_PATH = '/v1/platform/blog';
+
+    private EntityManagerInterface $entityManager;
+
+    /**
+     * @throws Throwable
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->entityManager = static::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('DELETE /v1/platform/blog/{id} removes a blog for its owner')]
+    public function testOwnerCanDeleteBlog(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+        $client->request('POST', self::BASE_PATH, [
+            'title' => 'Blog To Delete ' . uniqid('', true),
+            'description' => 'Disposable blog',
+        ]);
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $createdPayload = JSON::decode($content, true);
+        $slug = $createdPayload['slug'] ?? null;
+        self::assertIsString($slug);
+
+        /** @var Blog|null $blog */
+        $blog = $this->entityManager->getRepository(Blog::class)->findOneBy(['slug' => $slug]);
+        self::assertNotNull($blog);
+
+        $client->request('DELETE', self::BASE_PATH . '/' . $blog->getId());
+
+        $deleteResponse = $client->getResponse();
+        self::assertSame(Response::HTTP_NO_CONTENT, $deleteResponse->getStatusCode(), "Response:\n" . $deleteResponse);
+
+        /** @var Blog|null $deletedBlog */
+        $deletedBlog = $this->entityManager->getRepository(Blog::class)->find($blog->getId());
+        self::assertNull($deletedBlog);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('DELETE /v1/platform/blog/{id} rejects non-owner requests')]
+    public function testNonOwnerCannotDeleteBlog(): void
+    {
+        $ownerClient = $this->getTestClient('john-admin', 'password-admin');
+        $ownerClient->request('POST', self::BASE_PATH, [
+            'title' => 'Protected Blog ' . uniqid('', true),
+            'description' => 'Should survive',
+        ]);
+
+        $response = $ownerClient->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $createdPayload = JSON::decode($content, true);
+        $slug = $createdPayload['slug'] ?? null;
+        self::assertIsString($slug);
+
+        /** @var Blog|null $blog */
+        $blog = $this->entityManager->getRepository(Blog::class)->findOneBy(['slug' => $slug]);
+        self::assertNotNull($blog);
+
+        $attackerClient = $this->getTestClient('john-user', 'password-user');
+        $attackerClient->request('DELETE', self::BASE_PATH . '/' . $blog->getId());
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $attackerClient->getResponse()->getStatusCode());
+
+        /** @var Blog|null $stillThere */
+        $stillThere = $this->entityManager->getRepository(Blog::class)->find($blog->getId());
+        self::assertNotNull($stillThere);
+    }
+}

--- a/tests/Application/Blog/Transport/Controller/Frontend/EditBlogControllerTest.php
+++ b/tests/Application/Blog/Transport/Controller/Frontend/EditBlogControllerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Blog\Transport\Controller\Frontend;
+
+use App\Blog\Domain\Entity\Blog;
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+use function uniqid;
+
+final class EditBlogControllerTest extends WebTestCase
+{
+    private const string BASE_PATH = '/v1/platform/blog';
+
+    private EntityManagerInterface $entityManager;
+
+    /**
+     * @throws Throwable
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->entityManager = static::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('PATCH /v1/platform/blog/{id} allows blog owners to update their blog')]
+    public function testOwnerCanUpdateBlog(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $client->request('POST', self::BASE_PATH, [
+            'title' => 'Owner Blog ' . uniqid('', true),
+            'description' => 'Initial description',
+        ]);
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $createdPayload = JSON::decode($content, true);
+        $slug = $createdPayload['slug'] ?? null;
+        self::assertIsString($slug);
+
+        /** @var Blog|null $blog */
+        $blog = $this->entityManager->getRepository(Blog::class)->findOneBy(['slug' => $slug]);
+        self::assertNotNull($blog, 'Blog was not created successfully.');
+
+        $client->request(
+            method: 'PATCH',
+            uri: self::BASE_PATH . '/' . $blog->getId(),
+            content: JSON::encode([
+                'title' => 'Updated Title',
+                'description' => 'Updated Subtitle',
+            ])
+        );
+
+        $updateResponse = $client->getResponse();
+        $updateContent = $updateResponse->getContent();
+        self::assertNotFalse($updateContent);
+        self::assertSame(Response::HTTP_OK, $updateResponse->getStatusCode(), "Response:\n" . $updateResponse);
+
+        $payload = JSON::decode($updateContent, true);
+        self::assertSame('Updated Title', $payload['title']);
+        self::assertSame('Updated Subtitle', $payload['description']);
+
+        /** @var Blog|null $updatedBlog */
+        $updatedBlog = $this->entityManager->getRepository(Blog::class)->findOneBy(['slug' => $payload['slug']]);
+        self::assertNotNull($updatedBlog);
+        self::assertSame('Updated Title', $updatedBlog->getTitle());
+        self::assertSame('Updated Subtitle', $updatedBlog->getBlogSubtitle());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('PATCH /v1/platform/blog/{id} denies access for non-owners')]
+    public function testNonOwnerCannotUpdateBlog(): void
+    {
+        $ownerClient = $this->getTestClient('john-admin', 'password-admin');
+        $ownerClient->request('POST', self::BASE_PATH, [
+            'title' => 'Foreign Blog ' . uniqid('', true),
+            'description' => 'Initial description',
+        ]);
+
+        $response = $ownerClient->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $createdPayload = JSON::decode($content, true);
+        $slug = $createdPayload['slug'] ?? null;
+        self::assertIsString($slug);
+
+        /** @var Blog|null $blog */
+        $blog = $this->entityManager->getRepository(Blog::class)->findOneBy(['slug' => $slug]);
+        self::assertNotNull($blog);
+
+        $attackerClient = $this->getTestClient('john-user', 'password-user');
+        $attackerClient->request(
+            method: 'PATCH',
+            uri: self::BASE_PATH . '/' . $blog->getId(),
+            content: JSON::encode([
+                'title' => 'Hijacked Title',
+            ])
+        );
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $attackerClient->getResponse()->getStatusCode());
+
+        /** @var Blog|null $unchangedBlog */
+        $unchangedBlog = $this->entityManager->getRepository(Blog::class)->find($blog->getId());
+        self::assertNotNull($unchangedBlog);
+        self::assertSame($blog->getTitle(), $unchangedBlog->getTitle());
+    }
+}


### PR DESCRIPTION
## Summary
- add frontend edit controller to update blog metadata, handle logo uploads, and clear caches
- add frontend delete controller to enforce ownership, remove blogs, and invalidate caches
- cover edit and delete flows with application-level functional tests

## Testing
- composer install --no-interaction --no-progress *(fails: missing required PHP extensions ext-amqp, ext-sodium)*
- ./tools/01_phpunit/vendor/bin/phpunit tests/Application/Blog/Transport/Controller/Frontend/EditBlogControllerTest.php *(not run: missing phpunit binary prior to dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68d333e08b308326afe5980f21d6455c