### PR TITLE
Handle missing post title in string cast

### DIFF
--- a/src/Blog/Domain/Entity/Post.php
+++ b/src/Blog/Domain/Entity/Post.php
@@ -182,7 +182,7 @@ class Post implements EntityInterface, Stringable
 
     public function __toString(): string
     {
-        return $this->getTitle();
+        return $this->getTitle() ?? '';
     }
 
     public function getId(): string

--- a/tests/Unit/Blog/Entity/PostTest.php
+++ b/tests/Unit/Blog/Entity/PostTest.php
@@ -106,4 +106,12 @@ class PostTest extends TestCase
         self::assertIsArray($payload['likes']);
         self::assertIsArray($payload['reactions']);
     }
+
+    #[TestDox('It casts to an empty string when no title is set')]
+    public function testToStringWithNullTitle(): void
+    {
+        $post = new Post();
+
+        self::assertSame('', (string)$post);
+    }
 }


### PR DESCRIPTION
## Summary
- guard the Post entity string cast against null titles
- cover the cast behaviour with a unit test when no title is set

## Testing
- composer install --no-interaction --no-progress *(fails: missing ext-amqp, ext-sodium)*

------
https://chatgpt.com/codex/tasks/task_e_68d342ccd2448326872055e33dcc8f79