### PR TITLE
Handle empty comment content safely

### DIFF
--- a/src/Blog/Domain/Entity/Comment.php
+++ b/src/Blog/Domain/Entity/Comment.php
@@ -133,7 +133,7 @@ class Comment implements EntityInterface
 
     public function __toString(): string
     {
-        return $this->getContent();
+        return $this->content ?? '';
     }
 
     public function getId(): string
@@ -144,6 +144,10 @@ class Comment implements EntityInterface
     #[Assert\IsTrue(message: 'comment.is_spam')]
     public function isLegitComment(): bool
     {
+        if ($this->content === null || $this->content === '') {
+            return true;
+        }
+
         $containsInvalidCharacters = u($this->content)->indexOf('@') !== null;
 
         return !$containsInvalidCharacters;

--- a/tests/Unit/Blog/Entity/CommentTest.php
+++ b/tests/Unit/Blog/Entity/CommentTest.php
@@ -67,4 +67,18 @@ class CommentTest extends TestCase
         self::assertInstanceOf(Collection::class, $comment->getLikes());
         self::assertInstanceOf(Collection::class, $comment->getReactions());
     }
+
+    #[TestDox('It safely handles comments without content')]
+    public function testCommentWithoutContentIsSafe(): void
+    {
+        $comment = new Comment();
+
+        self::assertSame('', (string)$comment);
+        self::assertTrue($comment->isLegitComment());
+
+        $comment->setContent('');
+
+        self::assertSame('', (string)$comment);
+        self::assertTrue($comment->isLegitComment());
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `Comment::__toString()` gracefully falls back to an empty string when no content is set
- guard `Comment::isLegitComment()` against null or empty content values before running string operations
- cover comment behaviour without content in unit tests to verify safe handling

## Testing
- `vendor/bin/phpunit tests/Unit/Blog/Entity/CommentTest.php` *(fails: vendor directory and PHP extensions missing in environment)*
- `composer install --no-interaction` *(fails: required PHP extensions ext-amqp and ext-sodium unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d342d0d7c083268dce5a986c4635ef