### PR TITLE
Remove unused searchMedias method

### DIFF
--- a/src/Blog/Application/ApiProxy/UserProxy.php
+++ b/src/Blog/Application/ApiProxy/UserProxy.php
@@ -92,16 +92,6 @@ readonly class UserProxy
     }
 
     /**
-     * Searches media as a fallback method (likely unnecessary here).
-     *
-     * @throws InvalidArgumentException
-     */
-    public function searchMedias(string $query): array
-    {
-        return $this->userCacheService->search($query);
-    }
-
-    /**
      * Retrieves several users by ID list and caches them with the "users" tag.
      *
      * @param string[] $ids


### PR DESCRIPTION
## Summary
- delete the unused searchMedias method from the UserProxy API proxy
- clean up the obsolete docblock associated with the removed method

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d34958d5f883268534ac88eed95ac3