### PR TITLE
Remove unused getRandomText helper from blog fixtures

### DIFF
--- a/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
+++ b/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
@@ -210,11 +210,6 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
         return $titles;
     }
 
-    private function getRandomText(): string
-    {
-        return $this->faker->text(255);
-    }
-
     /**
      * @throws Exception
      */


### PR DESCRIPTION
## Summary
- remove the unused getRandomText helper from the blog data fixture
- ensure no references remain to the deleted helper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3495a6ae88326bad2afe72e184390