### PR TITLE
Remove unused extractSearchTerms helper

### DIFF
--- a/src/Blog/Infrastructure/Repository/PostRepository.php
+++ b/src/Blog/Infrastructure/Repository/PostRepository.php
@@ -16,7 +16,6 @@ use Exception;
 use Ramsey\Uuid\Uuid;
 
 use function sprintf;
-use function Symfony\Component\String\u;
 
 /**
  * @package App\Blog
@@ -169,21 +168,6 @@ class PostRepository extends BaseRepository implements PostRepositoryInterface
         }
 
         return $complete;
-    }
-
-    /**
-     * Transforms the search string into an array of search terms.
-     *
-     * @return string[]
-     */
-    private function extractSearchTerms(string $searchQuery): array
-    {
-        $terms = array_unique(u($searchQuery)->replaceMatches('/[[:space:]]+/', ' ')->trim()->split(' '));
-
-        // ignore the search terms that are too short
-        return array_filter($terms, static function ($term) {
-            return $term->length() >= 2;
-        });
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove the unused `extractSearchTerms` helper from `PostRepository`
- drop the now-unused Symfony string helper import

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3495bcb788326a39a18edb5c0ea40