### PR TITLE
Remove unused parameters from DeletePostController

### DIFF
--- a/src/Blog/Transport/Controller/Frontend/Post/DeletePostController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/DeletePostController.php
@@ -7,7 +7,6 @@ namespace App\Blog\Transport\Controller\Frontend\Post;
 use App\Blog\Domain\Entity\Post;
 use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;
 use App\General\Domain\Utils\JSON;
-use App\General\Infrastructure\ValueObject\SymfonyUser;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use JsonException;
@@ -41,7 +40,7 @@ readonly class DeletePostController
      * @throws OptimisticLockException
      */
     #[Route(path: '/v1/platform/post/{post}', name: 'delete_post', methods: [Request::METHOD_DELETE])]
-    public function __invoke(SymfonyUser $symfonyUser, Request $request, Post $post): JsonResponse
+    public function __invoke(Post $post): JsonResponse
     {
         $this->postRepository->remove($post);
         $output = JSON::decode(


### PR DESCRIPTION
## Summary
- update the frontend post delete controller to drop unused SymfonyUser and Request arguments
- remove the unused SymfonyUser import and keep the Request import for the route definition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d349616dcc8326ae0b1bf5e963c21e