### PR TITLE
Remove unused parameters from dislike controller

### DIFF
--- a/src/Blog/Transport/Controller/Frontend/React/DislikePostController.php
+++ b/src/Blog/Transport/Controller/Frontend/React/DislikePostController.php
@@ -7,7 +7,6 @@ namespace App\Blog\Transport\Controller\Frontend\React;
 use App\Blog\Domain\Entity\Like;
 use App\Blog\Domain\Repository\Interfaces\LikeRepositoryInterface;
 use App\General\Domain\Utils\JSON;
-use App\General\Infrastructure\ValueObject\SymfonyUser;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use JsonException;
@@ -41,7 +40,7 @@ readonly class DislikePostController
      * @throws OptimisticLockException
      */
     #[Route(path: '/v1/platform/post/{like}/dislike', name: 'dislike_post', methods: [Request::METHOD_POST])]
-    public function __invoke(SymfonyUser $symfonyUser, Request $request, Like $like): JsonResponse
+    public function __invoke(Like $like): JsonResponse
     {
         $this->likeRepository->remove($like);
 


### PR DESCRIPTION
## Summary
- remove the unused SymfonyUser and Request parameters from the dislike controller action
- drop the unused SymfonyUser import

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d34961e3988326bbee986be18806ec