### PR TITLE
Remove unused SymfonyUser dependency from edit comment controller

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -34,6 +34,7 @@ security:
     access_control:
         # - { path: ^/admin, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }
+        - { path: ^/v1/platform, roles: IS_AUTHENTICATED_FULLY }
         - { path: ^/command-scheduler, roles: ROLE_ADMIN }
         - { path: ^/api/public, roles: IS_AUTHENTICATED_ANONYMOUSLY }
 when@test:

--- a/src/Blog/Transport/Controller/Frontend/Comment/EditCommentController.php
+++ b/src/Blog/Transport/Controller/Frontend/Comment/EditCommentController.php
@@ -7,7 +7,6 @@ namespace App\Blog\Transport\Controller\Frontend\Comment;
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Infrastructure\Repository\CommentRepository;
 use App\General\Domain\Utils\JSON;
-use App\General\Infrastructure\ValueObject\SymfonyUser;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use JsonException;
@@ -41,7 +40,7 @@ readonly class EditCommentController
      * @throws OptimisticLockException
      */
     #[Route(path: '/v1/platform/comment/{comment}', name: 'edit_comment', methods: [Request::METHOD_PUT])]
-    public function __invoke(SymfonyUser $symfonyUser, Request $request, Comment $comment): JsonResponse
+    public function __invoke(Request $request, Comment $comment): JsonResponse
     {
         $data = $request->request->all();
         $comment->setContent($data['content']);


### PR DESCRIPTION
## Summary
- remove the unused SymfonyUser argument from the edit comment controller
- enforce authentication for /v1/platform routes through access control configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3495d2eec832682864661f03ce497