### PR TITLE
feat: add caching service for comment-related payloads

### DIFF
--- a/src/Blog/Application/Service/CommentCacheService.php
+++ b/src/Blog/Application/Service/CommentCacheService.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Service;
+
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+/**
+ * @package App\Blog\Application\Service
+ */
+readonly class CommentCacheService
+{
+    private const DEFAULT_TTL = 20;
+
+    public function __construct(private TagAwareCacheInterface $cache)
+    {
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable():T $callback
+     *
+     * @return T
+     */
+    public function getPostComments(string $postId, int $page, int $limit, callable $callback, ?string $context = null): mixed
+    {
+        return $this->getCachedPayload(
+            prefix: 'post_comments',
+            resourceId: $postId,
+            page: $page,
+            limit: $limit,
+            tags: ['posts', 'comments'],
+            callback: $callback,
+            context: $context,
+        );
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable():T $callback
+     *
+     * @return T
+     */
+    public function getPostLikes(string $postId, callable $callback): mixed
+    {
+        return $this->getCachedPayload(
+            prefix: 'post_likes',
+            resourceId: $postId,
+            tags: ['posts', 'likes'],
+            callback: $callback,
+        );
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable():T $callback
+     *
+     * @return T
+     */
+    public function getPostReactions(string $postId, callable $callback): mixed
+    {
+        return $this->getCachedPayload(
+            prefix: 'post_reactions',
+            resourceId: $postId,
+            tags: ['posts', 'reactions'],
+            callback: $callback,
+        );
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable():T $callback
+     *
+     * @return T
+     */
+    public function getCommentLikes(string $commentId, callable $callback, ?int $page = null, ?int $limit = null): mixed
+    {
+        return $this->getCachedPayload(
+            prefix: 'comment_likes',
+            resourceId: $commentId,
+            page: $page,
+            limit: $limit,
+            tags: ['comments', 'likes'],
+            callback: $callback,
+        );
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable():T $callback
+     *
+     * @return T
+     */
+    public function getCommentReactions(string $commentId, callable $callback, ?int $page = null, ?int $limit = null): mixed
+    {
+        return $this->getCachedPayload(
+            prefix: 'comment_reactions',
+            resourceId: $commentId,
+            page: $page,
+            limit: $limit,
+            tags: ['comments', 'reactions'],
+            callback: $callback,
+        );
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable():T $callback
+     *
+     * @return T
+     */
+    private function getCachedPayload(
+        string $prefix,
+        string $resourceId,
+        callable $callback,
+        array $tags,
+        ?int $page = null,
+        ?int $limit = null,
+        ?string $context = null,
+    ): mixed {
+        $cacheKey = $this->buildCacheKey($prefix, $resourceId, $page, $limit, $context);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($tags, $callback) {
+            $item->expiresAfter(self::DEFAULT_TTL);
+            $item->tag($tags);
+
+            return $callback();
+        });
+    }
+
+    private function buildCacheKey(
+        string $prefix,
+        string $resourceId,
+        ?int $page = null,
+        ?int $limit = null,
+        ?string $context = null,
+    ): string {
+        $parts = [$prefix, $resourceId];
+
+        if ($context !== null) {
+            $parts[] = $context;
+        }
+
+        if ($page !== null) {
+            $parts[] = 'page_' . $page;
+        }
+
+        if ($limit !== null) {
+            $parts[] = 'limit_' . $limit;
+        }
+
+        return implode('_', $parts);
+    }
+}

--- a/src/Blog/Transport/Controller/Frontend/Post/PostsController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/PostsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Frontend\Post;
 
 use App\Blog\Application\ApiProxy\UserProxy;
+use App\Blog\Application\Service\CommentCacheService;
 use App\Blog\Application\Service\CommentResponseHelper;
 use App\Blog\Application\Service\PostFeedResponseBuilder;
 use App\Blog\Domain\Entity\Comment;
@@ -44,6 +45,7 @@ readonly class PostsController
         private UserProxy $userProxy,
         private CommentResponseHelper $commentResponseHelper,
         private PostFeedResponseBuilder $postFeedResponseBuilder,
+        private CommentCacheService $commentCacheService,
     ) {
     }
 
@@ -90,36 +92,45 @@ readonly class PostsController
         $limit = (int)$request->query->get('limit', 10);
         $offset = ($page - 1) * $limit;
 
-        $comments = $this->postRepository->getRootComments($id, $limit, $offset);
-        $total = $this->postRepository->countComments($id);
+        $payload = $this->commentCacheService->getPostComments(
+            $id,
+            $page,
+            $limit,
+            function () use ($id, $limit, $offset, $page) {
+                $comments = $this->postRepository->getRootComments($id, $limit, $offset);
+                $total = $this->postRepository->countComments($id);
 
-        $userIds = [];
-        foreach ($comments as $comment) {
-            $userIds[] = $comment->getAuthor()->toString();
-            foreach ($comment->getLikes() as $like) {
-                $userIds[] = $like->getUser()->toString();
+                $userIds = [];
+                foreach ($comments as $comment) {
+                    $userIds[] = $comment->getAuthor()->toString();
+                    foreach ($comment->getLikes() as $like) {
+                        $userIds[] = $like->getUser()->toString();
+                    }
+                    foreach ($comment->getReactions() as $reaction) {
+                        $userIds[] = $reaction->getUser()->toString();
+                    }
+                }
+
+                $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
+
+                $data = array_map(
+                    fn (Comment $comment) => $this->commentResponseHelper->buildCommentThread(
+                        $comment,
+                        $users,
+                        includeLikesCount: true,
+                    ),
+                    $comments,
+                );
+
+                return [
+                    'comments' => $data,
+                    'total' => $total,
+                    'page' => $page,
+                ];
             }
-            foreach ($comment->getReactions() as $reaction) {
-                $userIds[] = $reaction->getUser()->toString();
-            }
-        }
-
-        $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
-
-        $data = array_map(
-            fn (Comment $comment) => $this->commentResponseHelper->buildCommentThread(
-                $comment,
-                $users,
-                includeLikesCount: true,
-            ),
-            $comments,
         );
 
-        return new JsonResponse([
-            'comments' => $data,
-            'total' => $total,
-            'page' => $page,
-        ]);
+        return new JsonResponse($payload);
     }
 
     /**
@@ -138,27 +149,34 @@ readonly class PostsController
     #[Route('/public/post/{id}/likes', name: 'public_post_likes', methods: ['GET'])]
     public function likes(string $id): JsonResponse
     {
-        $post = $this->postRepository->find($id);
+        $payload = $this->commentCacheService->getPostLikes(
+            $id,
+            function () use ($id) {
+                $post = $this->postRepository->find($id);
 
-        $likes = $post?->getLikes()?->toArray() ?? [];
-        $reactions = $post?->getReactions()?->toArray() ?? [];
+                $likes = $post?->getLikes()?->toArray() ?? [];
+                $reactions = $post?->getReactions()?->toArray() ?? [];
 
-        $userIds = array_merge(
-            array_map(static fn ($like) => $like->getUser()->toString(), $likes),
-            array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions),
+                $userIds = array_merge(
+                    array_map(static fn ($like) => $like->getUser()->toString(), $likes),
+                    array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions),
+                );
+
+                $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
+
+                $likesPayload = $this->commentResponseHelper->buildLikeList($likes, $users);
+                $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
+
+                return [
+                    'likes' => $likesPayload,
+                    'reactions' => $reactionsPayload,
+                    'total_likes' => count($likesPayload),
+                    'total_reactions' => count($reactionsPayload),
+                ];
+            }
         );
 
-        $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
-
-        $likesPayload = $this->commentResponseHelper->buildLikeList($likes, $users);
-        $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
-
-        return new JsonResponse([
-            'likes' => $likesPayload,
-            'reactions' => $reactionsPayload,
-            'total_likes' => count($likesPayload),
-            'total_reactions' => count($reactionsPayload),
-        ]);
+        return new JsonResponse($payload);
     }
 
     /**
@@ -177,27 +195,34 @@ readonly class PostsController
     #[Route('/public/comment/{id}/likes', name: 'public_comment_likes', methods: ['GET'])]
     public function commentLikes(string $id): JsonResponse
     {
-        $comment = $this->commentRepository->find($id);
+        $payload = $this->commentCacheService->getCommentLikes(
+            $id,
+            function () use ($id) {
+                $comment = $this->commentRepository->find($id);
 
-        $likes = $comment?->getLikes()?->toArray() ?? [];
-        $reactions = $comment?->getReactions()?->toArray() ?? [];
+                $likes = $comment?->getLikes()?->toArray() ?? [];
+                $reactions = $comment?->getReactions()?->toArray() ?? [];
 
-        $userIds = array_merge(
-            array_map(static fn ($like) => $like->getUser()->toString(), $likes),
-            array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions),
+                $userIds = array_merge(
+                    array_map(static fn ($like) => $like->getUser()->toString(), $likes),
+                    array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions),
+                );
+
+                $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
+
+                $likesPayload = $this->commentResponseHelper->buildLikeList($likes, $users);
+                $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
+
+                return [
+                    'likes' => $likesPayload,
+                    'reactions' => $reactionsPayload,
+                    'total_likes' => count($likesPayload),
+                    'total_reactions' => count($reactionsPayload),
+                ];
+            }
         );
 
-        $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
-
-        $likesPayload = $this->commentResponseHelper->buildLikeList($likes, $users);
-        $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
-
-        return new JsonResponse([
-            'likes' => $likesPayload,
-            'reactions' => $reactionsPayload,
-            'total_likes' => count($likesPayload),
-            'total_reactions' => count($reactionsPayload),
-        ]);
+        return new JsonResponse($payload);
     }
 
     /**
@@ -216,18 +241,25 @@ readonly class PostsController
     #[Route('/public/post/{id}/reactions', name: 'public_post_reactions', methods: ['GET'])]
     public function reactions(string $id): JsonResponse
     {
-        $post = $this->postRepository->find($id);
+        $payload = $this->commentCacheService->getPostReactions(
+            $id,
+            function () use ($id) {
+                $post = $this->postRepository->find($id);
 
-        $reactions = $post?->getReactions()?->toArray() ?? [];
-        $userIds = array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions);
-        $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
+                $reactions = $post?->getReactions()?->toArray() ?? [];
+                $userIds = array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions);
+                $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
 
-        $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
+                $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
 
-        return new JsonResponse([
-            'reactions' => $reactionsPayload,
-            'total' => count($reactionsPayload),
-        ]);
+                return [
+                    'reactions' => $reactionsPayload,
+                    'total' => count($reactionsPayload),
+                ];
+            }
+        );
+
+        return new JsonResponse($payload);
     }
 
     /**
@@ -252,15 +284,22 @@ readonly class PostsController
             ], 404);
         }
 
-        $reactions = $comment->getReactions()->toArray();
-        $userIds = array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions);
-        $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
+        $payload = $this->commentCacheService->getCommentReactions(
+            $id,
+            function () use ($comment) {
+                $reactions = $comment->getReactions()->toArray();
+                $userIds = array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions);
+                $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
 
-        $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
+                $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
 
-        return new JsonResponse([
-            'reactions' => $reactionsPayload,
-            'total' => count($reactionsPayload),
-        ]);
+                return [
+                    'reactions' => $reactionsPayload,
+                    'total' => count($reactionsPayload),
+                ];
+            }
+        );
+
+        return new JsonResponse($payload);
     }
 }

--- a/src/Blog/Transport/EventListener/CacheInvalidationListener.php
+++ b/src/Blog/Transport/EventListener/CacheInvalidationListener.php
@@ -58,7 +58,7 @@ final readonly class CacheInvalidationListener
             $entity instanceof Comment ||
             $entity instanceof Reaction
         ) {
-            $this->cache->invalidateTags(['posts']);
+            $this->cache->invalidateTags(['posts', 'comments', 'likes', 'reactions']);
         }
     }
 }

--- a/src/Blog/Transport/MessageHandler/CreatePostHandlerMessage.php
+++ b/src/Blog/Transport/MessageHandler/CreatePostHandlerMessage.php
@@ -58,13 +58,13 @@ readonly class CreatePostHandlerMessage
     {
         $this->postService->savePost($message->getPost(), $message->getMediasIds());
 
-        $this->cache->invalidateTags(['posts']);
+        $this->cache->invalidateTags(['posts', 'comments', 'likes', 'reactions']);
 
         $cacheKey = 'all_posts_' . 1 . '_' . 10;
         $this->cache->delete($cacheKey);
         $cacheKey = 'all_posts_' . 1 . '_' . 10;
 
-        $this->cache->invalidateTags(['posts']);
+        $this->cache->invalidateTags(['posts', 'comments', 'likes', 'reactions']);
         $this->cache->delete($cacheKey);
 
         $this->cache->get($cacheKey, fn (ItemInterface $item) => $this->getClosure(10, 1)($item));


### PR DESCRIPTION
## Summary
- add a dedicated CommentCacheService to centralize caching of comment, like, and reaction payloads with consistent TTLs and tags
- refactor public, private, and profile post controllers to consume the new cache service for comment, like, and reaction endpoints
- expand cache invalidation hooks to clear comment, like, and reaction tags whenever related entities change

## Testing
- php -l src/Blog/Application/Service/CommentCacheService.php
- php -l src/Blog/Transport/Controller/Frontend/Post/PostsController.php
- php -l src/Blog/Transport/Controller/Frontend/Post/LoggedPostsController.php
- php -l src/Blog/Transport/Controller/Frontend/Post/MyPostsController.php
- php -l src/Blog/Transport/EventListener/CacheInvalidationListener.php
- php -l src/Blog/Transport/MessageHandler/CreatePostHandlerMessage.php

------
https://chatgpt.com/codex/tasks/task_e_68d34d99ef9083269f7be4563c10d069