### PR TITLE
Refine post creation cache warm-up

### DIFF
--- a/src/Blog/Application/Service/PostFeedCacheService.php
+++ b/src/Blog/Application/Service/PostFeedCacheService.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Service;
+
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+use function sprintf;
+
+final readonly class PostFeedCacheService
+{
+    private const DEFAULT_TTL = 20;
+    private const CACHE_TAGS = ['posts', 'comments', 'likes', 'reactions'];
+
+    public function __construct(private TagAwareCacheInterface $cache)
+    {
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable():T $warmUp
+     *
+     * @return T
+     */
+    public function get(int $page, int $limit, callable $warmUp): mixed
+    {
+        return $this->cache->get($this->buildCacheKey($page, $limit), function (ItemInterface $item) use ($warmUp) {
+            $item->tag(self::CACHE_TAGS);
+            $item->expiresAfter(self::DEFAULT_TTL);
+
+            return $warmUp();
+        });
+    }
+
+    public function delete(int $page, int $limit): void
+    {
+        $this->cache->delete($this->buildCacheKey($page, $limit));
+    }
+
+    public function invalidateTags(): void
+    {
+        $this->cache->invalidateTags(self::CACHE_TAGS);
+    }
+
+    private function buildCacheKey(int $page, int $limit): string
+    {
+        return sprintf('posts_page_%d_limit_%d', $page, $limit);
+    }
+}

--- a/src/Blog/Transport/MessageHandler/CreatePostHandlerMessage.php
+++ b/src/Blog/Transport/MessageHandler/CreatePostHandlerMessage.php
@@ -4,25 +4,15 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\MessageHandler;
 
-use App\Blog\Application\ApiProxy\UserProxy;
+use App\Blog\Application\Service\PostFeedCacheService;
+use App\Blog\Application\Service\PostFeedResponseBuilder;
 use App\Blog\Application\Service\PostService;
-use App\Blog\Domain\Entity\Media;
 use App\Blog\Domain\Message\CreatePostMessenger;
 use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;
-use Closure;
-use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Exception\NotSupported;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
-use Symfony\Contracts\Cache\ItemInterface;
-use Symfony\Contracts\Cache\TagAwareCacheInterface;
-use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 /**
  * @package App\Post\Transport\MessageHandler
@@ -33,9 +23,9 @@ readonly class CreatePostHandlerMessage
 {
     public function __construct(
         private PostService $postService,
-        private TagAwareCacheInterface $cache,
+        private PostFeedCacheService $postFeedCacheService,
         private PostRepositoryInterface $postRepository,
-        private UserProxy $userProxy
+        private PostFeedResponseBuilder $postFeedResponseBuilder,
     ) {
     }
 
@@ -58,148 +48,19 @@ readonly class CreatePostHandlerMessage
     {
         $this->postService->savePost($message->getPost(), $message->getMediasIds());
 
-        $this->cache->invalidateTags(['posts', 'comments', 'likes', 'reactions']);
+        $page = 1;
+        $limit = 10;
 
-        $cacheKey = 'all_posts_' . 1 . '_' . 10;
-        $this->cache->delete($cacheKey);
-        $cacheKey = 'all_posts_' . 1 . '_' . 10;
+        $this->postFeedCacheService->invalidateTags();
+        $this->postFeedCacheService->delete($page, $limit);
 
-        $this->cache->invalidateTags(['posts', 'comments', 'likes', 'reactions']);
-        $this->cache->delete($cacheKey);
+        $this->postFeedCacheService->get($page, $limit, function () use ($page, $limit): array {
+            $offset = ($page - 1) * $limit;
 
-        $this->cache->get($cacheKey, fn (ItemInterface $item) => $this->getClosure(10, 1)($item));
-    }
+            $posts = $this->postRepository->findWithRelations($limit, $offset);
+            $total = $this->postRepository->countPosts();
 
-    private function getClosure($limit, $offset): Closure
-    {
-        return function (ItemInterface $item) use ($limit, $offset): array {
-            $item->tag(['posts']);
-            if (method_exists($item, 'tag')) {
-                $item->tag(['posts']);
-            }
-
-            $item->expiresAfter(31536000);
-
-            return $this->getFormattedPosts($limit, $offset);
-        };
-    }
-
-    /**
-     * @throws ClientExceptionInterface
-     * @throws DecodingExceptionInterface
-     * @throws NotSupported
-     * @throws RedirectionExceptionInterface
-     * @throws ServerExceptionInterface
-     * @throws TransportExceptionInterface
-     * @throws InvalidArgumentException
-     */
-    private function getFormattedPosts($limit, $offset): array
-    {
-        $posts = $this->getPosts($limit, $offset);
-        $output = [];
-
-        foreach ($posts as $post) {
-            $authorId = $post->getAuthor()->toString();
-
-            $postData = [
-                'id' => $post->getId(),
-                'title' => $post->getTitle(),
-                'url' => $post->getUrl(),
-                'summary' => $post->getSummary(),
-                'content' => $post->getContent(),
-                'slug' => $post->getSlug(),
-                'tags' => $post->getTags(),
-                'medias' => $this->getMedia($post->getMediaEntities()),
-                'likes' => [],
-                'publishedAt' => $post->getPublishedAt()?->format(DATE_ATOM),
-                'blog' => [
-                    'title' => $post->getBlog()?->getTitle(),
-                    'blogSubtitle' => $post->getBlog()?->getBlogSubtitle(),
-                ],
-                'user' => $this->userProxy->searchUser($authorId),
-                'comments' => [],
-            ];
-
-            foreach ($post->getLikes() as $key => $like) {
-                $postData['likes'][$key]['id'] = $like->getId();
-                $postData['likes'][$key]['user'] = $this->userProxy->searchUser($like->getUser()->toString());
-            }
-
-            $rootComments = array_filter(
-                $post->getComments()->toArray(),
-                static fn ($comment) => $comment->getParent() === null
-            );
-
-            foreach ($rootComments as $comment) {
-                $postData['comments'][] = $this->formatCommentRecursively($comment);
-            }
-
-            $output[] = $postData;
-        }
-
-        return $output;
-    }
-
-    /**
-     * @throws ClientExceptionInterface
-     * @throws DecodingExceptionInterface
-     * @throws InvalidArgumentException
-     * @throws RedirectionExceptionInterface
-     * @throws ServerExceptionInterface
-     * @throws TransportExceptionInterface
-     */
-    private function formatCommentRecursively($comment): array
-    {
-        $authorId = $comment->getAuthor()->toString();
-
-        $formatted = [
-            'id' => $comment->getId(),
-            'content' => $comment->getContent(),
-            'likes' => [],
-            'publishedAt' => $comment->getPublishedAt()?->format(DATE_ATOM),
-            'user' => $this->userProxy->searchUser($authorId),
-            'children' => [],
-        ];
-        foreach ($comment->getLikes() as $key => $like) {
-            $formatted['likes'][$key]['id'] = $like->getId();
-
-            $formatted['likes'][$key]['user'] = $this->userProxy->searchUser($like->getUser()->toString());
-        }
-        foreach ($comment->getChildren() as $child) {
-            $formatted['children'][] = $this->formatCommentRecursively($child);
-        }
-
-        return $formatted;
-    }
-
-    /**
-     * @throws ClientExceptionInterface
-     * @throws DecodingExceptionInterface
-     * @throws RedirectionExceptionInterface
-     * @throws ServerExceptionInterface
-     * @throws TransportExceptionInterface
-     */
-    private function getMedia(Collection $mediaEntities): array
-    {
-        $medias = [];
-        foreach ($mediaEntities as $media) {
-            if (!$media instanceof Media) {
-                continue;
-            }
-
-            $medias[] = $this->userProxy->getMedia($media->getId());
-        }
-
-        return $medias;
-    }
-
-    /**
-     * @throws NotSupported
-     */
-    private function getPosts($limit, $offset): array
-    {
-        return $this->postRepository->findBy([], [
-            'publishedAt' => 'DESC',
-        ], $limit, $offset);
+            return $this->postFeedResponseBuilder->build($posts, $page, $limit, $total);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- introduce a PostFeedCacheService to centralize feed cache keys, tags, and TTL handling
- update CreatePostHandlerMessage to rebuild the cached feed via PostFeedResponseBuilder after saving a post
- extend the posts cache integration test to ensure pagination metadata persists after cache warm-up

## Testing
- composer exec phpunit tests/Application/Blog/Transport/Controller/PostsControllerCacheTest.php *(fails: phpunit binary not available in environment)*
- composer install --no-interaction *(fails: missing ext-amqp / ext-sodium extensions)*
- composer install --no-interaction --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium *(fails: repeated 403 errors while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d3516fdf8483269b190eed01d9eb66