### PR TITLE
Fix comment notification sender id

### DIFF
--- a/src/Blog/Transport/MessageHandler/CreateCommentHandlerMessage.php
+++ b/src/Blog/Transport/MessageHandler/CreateCommentHandlerMessage.php
@@ -69,7 +69,7 @@ readonly class CreateCommentHandlerMessage
         $post = $this->postRepository->find($message->getPostId());
         $this->commentNotificationMailer->sendCommentNotificationEmail(
             $post?->getAuthor()->toString(),
-            $message->getUserId(),
+            $message->getSenderId(),
             $post?->getSlug()
         );
     }


### PR DESCRIPTION
## Summary
- ensure comment notification emails use the commenting user's id when rendering sender information

## Testing
- `composer install` *(fails: missing PHP extensions ext-amqp and ext-sodium in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d357ebb2048326ad2973d2258e8070