### PR TITLE
Add blog cache refresh command and scheduled job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,8 +347,9 @@ migrate: ## Runs all migrations for main/test databases
 	@make exec cmd="php bin/console doctrine:migrations:migrate --no-interaction --env=test"
 
 migrate-cron-jobs: ## Creates cron job tasks (cleanup logs, failed old messenger messages)
-	@make exec cmd="php bin/console scheduler:cleanup-logs"
-	@make exec cmd="php bin/console scheduler:cleanup-messenger-messages"
+        @make exec cmd="php bin/console scheduler:cleanup-logs"
+        @make exec cmd="php bin/console scheduler:cleanup-messenger-messages"
+        @make exec cmd="php bin/console doctrine:migrations:execute DoctrineMigrations\\Version20240901000000 --no-interaction --up"
 
 fixtures: ## Runs all fixtures for test database without --append option (tables will be dropped and recreated)
 	@make exec cmd="php bin/console doctrine:fixtures:load --env=test"

--- a/config/packages/test/cache.yaml
+++ b/config/packages/test/cache.yaml
@@ -1,0 +1,7 @@
+framework:
+    cache:
+        app: cache.adapter.array
+        pools:
+            cache.app.taggable:
+                adapter: cache.adapter.tag_aware
+                provider: cache.adapter.array

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -76,7 +76,7 @@ make logs-kibana                        # Shows logs from the kibana container. 
 make drop-migrate                       # Drops databases and runs all migrations for the main/test databases
 make migrate                            # Runs all migrations for the main/test databases
 make migrate-no-test                    # Runs all migrations for the main database
-make migrate-cron-jobs                  # Creates cron job tasks (cleanup logs, failed old messenger messages)
+make migrate-cron-jobs                  # Creates cron job tasks (cleanup logs, failed old messenger messages, blog cache refresh)
 
 make fixtures                           # Runs all fixtures for test database without --append option (tables will be dropped and recreated)
 
@@ -149,4 +149,5 @@ After above command you will be inside symfony container and for display list of
 ./bin/console logs:cleanup                          # Command to cleanup logs(log_login, log_request) in the database (runs by cron every day at 00-00)
 ./bin/console messenger:messages-cleanup            # Command to cleanup messenger_messages table (runs by cron every day at 00-00)
 ./bin/console elastic:create-or-update-template     # Command in order to create/update index template in Elastic
+./bin/console blog:cache:refresh                    # Warm up blog related caches (use --scope=posts|comments|reactions|all)
 ```

--- a/migrations/Version20240901000000.php
+++ b/migrations/Version20240901000000.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20240901000000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Register scheduled commands for blog cache refresh.';
+    }
+
+    #[Override]
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+INSERT INTO scheduled_command (name, command, arguments, cron_expression, priority, execute_immediately, disabled, locked, ping_back_url, ping_back_failed_url, notes, version, created_at)
+VALUES
+    ('blog_cache_refresh_posts', 'blog:cache:refresh', '--scope=posts', '*/5 * * * *', 0, 0, 0, 0, NULL, NULL, 'Refreshes the public blog feed cache', 1, NOW()),
+    ('blog_cache_refresh_comments', 'blog:cache:refresh', '--scope=comments', '*/5 * * * *', 0, 0, 0, 0, NULL, NULL, 'Refreshes blog comment caches', 1, NOW()),
+    ('blog_cache_refresh_reactions', 'blog:cache:refresh', '--scope=reactions', '*/5 * * * *', 0, 0, 0, 0, NULL, NULL, 'Refreshes blog likes and reactions caches', 1, NOW())
+ON DUPLICATE KEY UPDATE
+    command = VALUES(command),
+    arguments = VALUES(arguments),
+    cron_expression = VALUES(cron_expression),
+    priority = VALUES(priority),
+    execute_immediately = VALUES(execute_immediately),
+    disabled = VALUES(disabled),
+    locked = VALUES(locked),
+    notes = VALUES(notes)
+SQL
+        );
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+DELETE FROM scheduled_command
+WHERE name IN ('blog_cache_refresh_posts', 'blog_cache_refresh_comments', 'blog_cache_refresh_reactions')
+SQL
+        );
+    }
+}

--- a/src/Blog/Application/Service/PostCachePayloadBuilder.php
+++ b/src/Blog/Application/Service/PostCachePayloadBuilder.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Service;
+
+use App\Blog\Application\ApiProxy\UserProxy;
+use App\Blog\Domain\Entity\Comment;
+use App\Blog\Domain\Entity\Post;
+use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;
+use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+
+use function array_map;
+use function array_merge;
+use function array_unique;
+use function count;
+use function max;
+
+/**
+ * Responsible for building the payloads used to warm blog related caches.
+ */
+final readonly class PostCachePayloadBuilder
+{
+    public function __construct(
+        private PostRepositoryInterface $postRepository,
+        private CommentRepositoryInterface $commentRepository,
+        private UserProxy $userProxy,
+        private CommentResponseHelper $commentResponseHelper,
+        private PostFeedResponseBuilder $postFeedResponseBuilder,
+    ) {
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function buildPostFeedPayload(int $page, int $limit): array
+    {
+        $page = max(1, $page);
+        $offset = ($page - 1) * $limit;
+
+        $posts = $this->postRepository->findWithRelations($limit, $offset);
+        $total = $this->postRepository->countPosts();
+
+        return $this->postFeedResponseBuilder->build($posts, $page, $limit, $total);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function buildPostCommentsPayload(string $postId, int $page, int $limit): array
+    {
+        $page = max(1, $page);
+        $offset = ($page - 1) * $limit;
+
+        $comments = $this->postRepository->getRootComments($postId, $limit, $offset);
+        $total = $this->postRepository->countComments($postId);
+
+        $userIds = [];
+        foreach ($comments as $comment) {
+            $userIds[] = $comment->getAuthor()->toString();
+
+            foreach ($comment->getLikes() as $like) {
+                $userIds[] = $like->getUser()->toString();
+            }
+
+            foreach ($comment->getReactions() as $reaction) {
+                $userIds[] = $reaction->getUser()->toString();
+            }
+        }
+
+        $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
+
+        $data = array_map(
+            fn (Comment $comment) => $this->commentResponseHelper->buildCommentThread(
+                $comment,
+                $users,
+                includeLikesCount: true,
+            ),
+            $comments,
+        );
+
+        return [
+            'comments' => $data,
+            'total' => $total,
+            'page' => $page,
+        ];
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function buildPostLikesPayload(string $postId, ?Post $post = null): array
+    {
+        $post ??= $this->postRepository->find($postId);
+
+        $likes = $post?->getLikes()?->toArray() ?? [];
+        $reactions = $post?->getReactions()?->toArray() ?? [];
+
+        $userIds = array_merge(
+            array_map(static fn ($like) => $like->getUser()->toString(), $likes),
+            array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions),
+        );
+
+        $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
+
+        $likesPayload = $this->commentResponseHelper->buildLikeList($likes, $users);
+        $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
+
+        return [
+            'likes' => $likesPayload,
+            'reactions' => $reactionsPayload,
+            'total_likes' => count($likesPayload),
+            'total_reactions' => count($reactionsPayload),
+        ];
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function buildPostReactionsPayload(string $postId, ?Post $post = null): array
+    {
+        $post ??= $this->postRepository->find($postId);
+        $reactions = $post?->getReactions()?->toArray() ?? [];
+
+        $userIds = array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions);
+        $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
+
+        $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
+
+        return [
+            'reactions' => $reactionsPayload,
+            'total' => count($reactionsPayload),
+        ];
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function buildCommentLikesPayload(string $commentId, ?Comment $comment = null): array
+    {
+        $comment ??= $this->commentRepository->find($commentId);
+
+        $likes = $comment?->getLikes()?->toArray() ?? [];
+        $reactions = $comment?->getReactions()?->toArray() ?? [];
+
+        $userIds = array_merge(
+            array_map(static fn ($like) => $like->getUser()->toString(), $likes),
+            array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions),
+        );
+
+        $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
+
+        $likesPayload = $this->commentResponseHelper->buildLikeList($likes, $users);
+        $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
+
+        return [
+            'likes' => $likesPayload,
+            'reactions' => $reactionsPayload,
+            'total_likes' => count($likesPayload),
+            'total_reactions' => count($reactionsPayload),
+        ];
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     */
+    public function buildCommentReactionsPayload(string $commentId, ?Comment $comment = null): array
+    {
+        $comment ??= $this->commentRepository->find($commentId);
+        $reactions = $comment?->getReactions()?->toArray() ?? [];
+
+        $userIds = array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions);
+        $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
+
+        $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
+
+        return [
+            'reactions' => $reactionsPayload,
+            'total' => count($reactionsPayload),
+        ];
+    }
+}

--- a/src/Blog/Transport/Command/RefreshBlogCacheCommand.php
+++ b/src/Blog/Transport/Command/RefreshBlogCacheCommand.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Transport\Command;
+
+use App\Blog\Application\Service\CommentCacheService;
+use App\Blog\Application\Service\PostCachePayloadBuilder;
+use App\Blog\Application\Service\PostFeedCacheService;
+use App\Blog\Domain\Entity\Post;
+use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;
+use Override;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function array_merge;
+use function array_unique;
+use function in_array;
+use function sprintf;
+
+#[AsCommand(name: 'blog:cache:refresh', description: 'Warm up the blog caches for public feeds and related resources.')]
+final class RefreshBlogCacheCommand extends Command
+{
+    private const OPTION_SCOPE = 'scope';
+    private const DEFAULT_SCOPE = 'all';
+    private const SCOPES = ['posts', 'comments', 'reactions', 'all'];
+    private const DEFAULT_PAGE = 1;
+    private const DEFAULT_LIMIT = 10;
+
+    public function __construct(
+        private readonly PostRepositoryInterface $postRepository,
+        private readonly PostFeedCacheService $postFeedCacheService,
+        private readonly CommentCacheService $commentCacheService,
+        private readonly PostCachePayloadBuilder $postCachePayloadBuilder,
+    ) {
+        parent::__construct();
+    }
+
+    #[Override]
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                self::OPTION_SCOPE,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Select which caches should be refreshed (posts, comments, reactions, all).',
+                self::DEFAULT_SCOPE,
+            );
+    }
+
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $scope = (string)$input->getOption(self::OPTION_SCOPE);
+
+        if (!in_array($scope, self::SCOPES, true)) {
+            $io->error(sprintf('Invalid scope "%s". Allowed values: %s.', $scope, implode(', ', self::SCOPES)));
+
+            return Command::INVALID;
+        }
+
+        $page = self::DEFAULT_PAGE;
+        $limit = self::DEFAULT_LIMIT;
+
+        $shouldWarmPosts = $scope === 'posts' || $scope === 'all';
+        $shouldWarmComments = $scope === 'comments' || $scope === 'all';
+        $shouldWarmReactions = $scope === 'reactions' || $scope === 'all';
+
+        if ($shouldWarmPosts) {
+            $this->postFeedCacheService->get(
+                $page,
+                $limit,
+                fn () => $this->postCachePayloadBuilder->buildPostFeedPayload($page, $limit)
+            );
+        }
+
+        $posts = $this->postRepository->findWithRelations($limit, 0);
+        if ($posts === []) {
+            $io->warning('No posts were found to warm cache entries.');
+
+            return Command::SUCCESS;
+        }
+
+        foreach ($posts as $post) {
+            \assert($post instanceof Post);
+            $postId = $post->getId();
+
+            if ($shouldWarmComments) {
+                $commentsPayload = $this->commentCacheService->getPostComments(
+                    $postId,
+                    $page,
+                    $limit,
+                    fn () => $this->postCachePayloadBuilder->buildPostCommentsPayload($postId, $page, $limit)
+                );
+
+                if ($shouldWarmReactions) {
+                    $this->warmCommentCachesForPost($commentsPayload['comments'] ?? []);
+                }
+            }
+
+            if ($shouldWarmReactions) {
+                $this->commentCacheService->getPostLikes(
+                    $postId,
+                    fn () => $this->postCachePayloadBuilder->buildPostLikesPayload($postId, $post)
+                );
+
+                $this->commentCacheService->getPostReactions(
+                    $postId,
+                    fn () => $this->postCachePayloadBuilder->buildPostReactionsPayload($postId, $post)
+                );
+            }
+        }
+
+        $io->success(sprintf('Blog caches refreshed for scope "%s".', $scope));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $cachedComments
+     */
+    private function warmCommentCachesForPost(array $cachedComments): void
+    {
+        $commentIds = $this->collectCommentIds($cachedComments);
+        if ($commentIds === []) {
+            return;
+        }
+
+        foreach ($commentIds as $commentId) {
+            $this->commentCacheService->getCommentLikes(
+                $commentId,
+                fn () => $this->postCachePayloadBuilder->buildCommentLikesPayload($commentId)
+            );
+
+            $this->commentCacheService->getCommentReactions(
+                $commentId,
+                fn () => $this->postCachePayloadBuilder->buildCommentReactionsPayload($commentId)
+            );
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $comments
+     * @return string[]
+     */
+    private function collectCommentIds(array $comments): array
+    {
+        $ids = [];
+
+        foreach ($comments as $comment) {
+            if (!isset($comment['id'])) {
+                continue;
+            }
+
+            $ids[] = (string)$comment['id'];
+            $children = $comment['children'] ?? [];
+            if ($children !== []) {
+                $ids = array_merge($ids, $this->collectCommentIds($children));
+            }
+        }
+
+        return array_unique($ids);
+    }
+}

--- a/src/Blog/Transport/Controller/Frontend/Post/PostsController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/PostsController.php
@@ -4,27 +4,23 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\Controller\Frontend\Post;
 
-use App\Blog\Application\ApiProxy\UserProxy;
 use App\Blog\Application\Service\CommentCacheService;
-use App\Blog\Application\Service\CommentResponseHelper;
-use App\Blog\Application\Service\PostFeedResponseBuilder;
+use App\Blog\Application\Service\PostCachePayloadBuilder;
+use App\Blog\Application\Service\PostFeedCacheService;
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;
-use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;
 use Doctrine\ORM\Exception\NotSupported;
 use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\Exception\OptimisticLockException;
+use Doctrine\ORM\Exception\TransactionRequiredException;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
-use Doctrine\ORM\OptimisticLockException;
-use Doctrine\ORM\TransactionRequiredException;
 use OpenApi\Attributes as OA;
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
-use Symfony\Contracts\Cache\ItemInterface;
-use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
@@ -39,13 +35,10 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 readonly class PostsController
 {
     public function __construct(
-        private TagAwareCacheInterface $cache,
-        private PostRepositoryInterface $postRepository,
         private CommentRepositoryInterface $commentRepository,
-        private UserProxy $userProxy,
-        private CommentResponseHelper $commentResponseHelper,
-        private PostFeedResponseBuilder $postFeedResponseBuilder,
+        private PostFeedCacheService $postFeedCacheService,
         private CommentCacheService $commentCacheService,
+        private PostCachePayloadBuilder $postCachePayloadBuilder,
     ) {
     }
 
@@ -57,18 +50,7 @@ readonly class PostsController
     {
         $page = max(1, (int)$request->query->get('page', 1));
         $limit = (int)$request->query->get('limit', 10);
-        $offset = ($page - 1) * $limit;
-        $cacheKey = "posts_page_{$page}_limit_{$limit}";
-
-        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($limit, $offset, $page) {
-            $item->tag(['posts']);
-            $item->expiresAfter(20);
-
-            $posts = $this->postRepository->findWithRelations($limit, $offset);
-            $total = $this->postRepository->countPosts();
-
-            return $this->postFeedResponseBuilder->build($posts, $page, $limit, $total);
-        });
+        $result = $this->postFeedCacheService->get($page, $limit, fn () => $this->postCachePayloadBuilder->buildPostFeedPayload($page, $limit));
 
         return new JsonResponse($result);
     }
@@ -90,44 +72,12 @@ readonly class PostsController
     {
         $page = max(1, (int)$request->query->get('page', 1));
         $limit = (int)$request->query->get('limit', 10);
-        $offset = ($page - 1) * $limit;
 
         $payload = $this->commentCacheService->getPostComments(
             $id,
             $page,
             $limit,
-            function () use ($id, $limit, $offset, $page) {
-                $comments = $this->postRepository->getRootComments($id, $limit, $offset);
-                $total = $this->postRepository->countComments($id);
-
-                $userIds = [];
-                foreach ($comments as $comment) {
-                    $userIds[] = $comment->getAuthor()->toString();
-                    foreach ($comment->getLikes() as $like) {
-                        $userIds[] = $like->getUser()->toString();
-                    }
-                    foreach ($comment->getReactions() as $reaction) {
-                        $userIds[] = $reaction->getUser()->toString();
-                    }
-                }
-
-                $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
-
-                $data = array_map(
-                    fn (Comment $comment) => $this->commentResponseHelper->buildCommentThread(
-                        $comment,
-                        $users,
-                        includeLikesCount: true,
-                    ),
-                    $comments,
-                );
-
-                return [
-                    'comments' => $data,
-                    'total' => $total,
-                    'page' => $page,
-                ];
-            }
+            fn () => $this->postCachePayloadBuilder->buildPostCommentsPayload($id, $page, $limit)
         );
 
         return new JsonResponse($payload);
@@ -151,29 +101,7 @@ readonly class PostsController
     {
         $payload = $this->commentCacheService->getPostLikes(
             $id,
-            function () use ($id) {
-                $post = $this->postRepository->find($id);
-
-                $likes = $post?->getLikes()?->toArray() ?? [];
-                $reactions = $post?->getReactions()?->toArray() ?? [];
-
-                $userIds = array_merge(
-                    array_map(static fn ($like) => $like->getUser()->toString(), $likes),
-                    array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions),
-                );
-
-                $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
-
-                $likesPayload = $this->commentResponseHelper->buildLikeList($likes, $users);
-                $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
-
-                return [
-                    'likes' => $likesPayload,
-                    'reactions' => $reactionsPayload,
-                    'total_likes' => count($likesPayload),
-                    'total_reactions' => count($reactionsPayload),
-                ];
-            }
+            fn () => $this->postCachePayloadBuilder->buildPostLikesPayload($id)
         );
 
         return new JsonResponse($payload);
@@ -195,31 +123,11 @@ readonly class PostsController
     #[Route('/public/comment/{id}/likes', name: 'public_comment_likes', methods: ['GET'])]
     public function commentLikes(string $id): JsonResponse
     {
+        $comment = $this->commentRepository->find($id);
+
         $payload = $this->commentCacheService->getCommentLikes(
             $id,
-            function () use ($id) {
-                $comment = $this->commentRepository->find($id);
-
-                $likes = $comment?->getLikes()?->toArray() ?? [];
-                $reactions = $comment?->getReactions()?->toArray() ?? [];
-
-                $userIds = array_merge(
-                    array_map(static fn ($like) => $like->getUser()->toString(), $likes),
-                    array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions),
-                );
-
-                $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
-
-                $likesPayload = $this->commentResponseHelper->buildLikeList($likes, $users);
-                $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
-
-                return [
-                    'likes' => $likesPayload,
-                    'reactions' => $reactionsPayload,
-                    'total_likes' => count($likesPayload),
-                    'total_reactions' => count($reactionsPayload),
-                ];
-            }
+            fn () => $this->postCachePayloadBuilder->buildCommentLikesPayload($id, $comment)
         );
 
         return new JsonResponse($payload);
@@ -243,20 +151,7 @@ readonly class PostsController
     {
         $payload = $this->commentCacheService->getPostReactions(
             $id,
-            function () use ($id) {
-                $post = $this->postRepository->find($id);
-
-                $reactions = $post?->getReactions()?->toArray() ?? [];
-                $userIds = array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions);
-                $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
-
-                $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
-
-                return [
-                    'reactions' => $reactionsPayload,
-                    'total' => count($reactionsPayload),
-                ];
-            }
+            fn () => $this->postCachePayloadBuilder->buildPostReactionsPayload($id)
         );
 
         return new JsonResponse($payload);
@@ -286,18 +181,7 @@ readonly class PostsController
 
         $payload = $this->commentCacheService->getCommentReactions(
             $id,
-            function () use ($comment) {
-                $reactions = $comment->getReactions()->toArray();
-                $userIds = array_map(static fn ($reaction) => $reaction->getUser()->toString(), $reactions);
-                $users = $this->userProxy->batchSearchUsers(array_unique($userIds));
-
-                $reactionsPayload = $this->commentResponseHelper->buildReactionList($reactions, $users);
-
-                return [
-                    'reactions' => $reactionsPayload,
-                    'total' => count($reactionsPayload),
-                ];
-            }
+            fn () => $this->postCachePayloadBuilder->buildCommentReactionsPayload($id, $comment)
         );
 
         return new JsonResponse($payload);

--- a/tests/Application/Blog/Transport/Command/RefreshBlogCacheCommandTest.php
+++ b/tests/Application/Blog/Transport/Command/RefreshBlogCacheCommandTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Blog\Transport\Command;
+
+use App\Blog\Application\ApiProxy\UserProxy;
+use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;
+use App\Tests\TestCase\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+use function array_reduce;
+use function sprintf;
+
+final class RefreshBlogCacheCommandTest extends WebTestCase
+{
+    public function testCommandWarmsCachesForAllScopes(): void
+    {
+        static::ensureKernelShutdown();
+        static::createClient();
+        $container = static::getContainer();
+        $this->overrideUserProxy($container);
+
+        /** @var TagAwareCacheInterface $cache */
+        $cache = $container->get(TagAwareCacheInterface::class);
+        $cache->clear();
+
+        $application = new Application(static::$kernel);
+        $command = $application->find('blog:cache:refresh');
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--scope' => 'all',
+        ]);
+        $tester->assertCommandIsSuccessful();
+
+        /** @var PostRepositoryInterface $postRepository */
+        $postRepository = $container->get(PostRepositoryInterface::class);
+        $post = $postRepository->findOneBy([]);
+        self::assertNotNull($post, 'Expected at least one post to exist.');
+
+        $postId = $post->getId();
+
+        $postFeedItem = $cache->getItem(sprintf('posts_page_%d_limit_%d', 1, 10));
+        self::assertTrue($postFeedItem->isHit());
+        self::assertSameCanonicalizing(['posts', 'comments', 'likes', 'reactions'], $postFeedItem->getMetadata()['tags'] ?? []);
+
+        $postCommentsItem = $cache->getItem(sprintf('post_comments_%s_page_%d_limit_%d', $postId, 1, 10));
+        self::assertTrue($postCommentsItem->isHit());
+        self::assertSameCanonicalizing(['posts', 'comments'], $postCommentsItem->getMetadata()['tags'] ?? []);
+
+        $postLikesItem = $cache->getItem(sprintf('post_likes_%s', $postId));
+        self::assertTrue($postLikesItem->isHit());
+        self::assertSameCanonicalizing(['posts', 'likes'], $postLikesItem->getMetadata()['tags'] ?? []);
+
+        $postReactionsItem = $cache->getItem(sprintf('post_reactions_%s', $postId));
+        self::assertTrue($postReactionsItem->isHit());
+        self::assertSameCanonicalizing(['posts', 'reactions'], $postReactionsItem->getMetadata()['tags'] ?? []);
+
+        $commentsPayload = $postCommentsItem->get();
+        self::assertIsArray($commentsPayload);
+        self::assertArrayHasKey('comments', $commentsPayload);
+        self::assertNotEmpty($commentsPayload['comments']);
+
+        $commentId = $this->extractFirstCommentId($commentsPayload['comments']);
+        self::assertNotNull($commentId, 'Expected to find at least one comment identifier.');
+
+        $commentLikesItem = $cache->getItem(sprintf('comment_likes_%s', $commentId));
+        self::assertTrue($commentLikesItem->isHit());
+        self::assertSameCanonicalizing(['comments', 'likes'], $commentLikesItem->getMetadata()['tags'] ?? []);
+
+        $commentReactionsItem = $cache->getItem(sprintf('comment_reactions_%s', $commentId));
+        self::assertTrue($commentReactionsItem->isHit());
+        self::assertSameCanonicalizing(['comments', 'reactions'], $commentReactionsItem->getMetadata()['tags'] ?? []);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $comments
+     */
+    private function extractFirstCommentId(array $comments): ?string
+    {
+        foreach ($comments as $comment) {
+            if (isset($comment['id'])) {
+                return (string)$comment['id'];
+            }
+
+            if (!empty($comment['children'])) {
+                $childId = $this->extractFirstCommentId($comment['children']);
+                if ($childId !== null) {
+                    return $childId;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function overrideUserProxy(ContainerInterface $container): void
+    {
+        $userProxy = $this->createMock(UserProxy::class);
+
+        $userProxy->method('batchSearchUsers')->willReturnCallback(
+            static fn (array $ids): array => array_reduce(
+                $ids,
+                static function (array $carry, string $id): array {
+                    $carry[$id] = [
+                        'id' => $id,
+                        'username' => sprintf('user_%s', $id),
+                    ];
+
+                    return $carry;
+                },
+                [],
+            ),
+        );
+
+        $userProxy->method('searchUser')->willReturnCallback(
+            static fn (string $id): array => [
+                'id' => $id,
+                'username' => sprintf('user_%s', $id),
+            ],
+        );
+
+        $userProxy->method('getUsers')->willReturn([]);
+        $userProxy->method('getMedia')->willReturnCallback(
+            static fn (string $id): array => [
+                'id' => $id,
+                'url' => sprintf('https://media.example/%s', $id),
+            ],
+        );
+
+        $container->set(UserProxy::class, $userProxy);
+        $container->set('App\\Blog\\Application\\ApiProxy\\UserProxy', $userProxy);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a PostCachePayloadBuilder to centralize post, comment, like and reaction payload generation
- switch the public posts controller to rely on the shared builder/PostFeedCacheService and add the new blog:cache:refresh command
- cover the command with a functional test, configure an in-memory cache adapter for tests, register the cron migration, and document the new job/command

## Testing
- Tests could not be executed: composer install requires downloading packages from GitHub, but the environment blocks the connections (CONNECT tunnel failed 403).

------
https://chatgpt.com/codex/tasks/task_e_68d358bf8e748326bc00d2fa496de478