### PR TITLE
Add notification email for comment replies

### DIFF
--- a/src/Blog/Application/Service/CommentNotificationMailer.php
+++ b/src/Blog/Application/Service/CommentNotificationMailer.php
@@ -6,6 +6,7 @@ namespace App\Blog\Application\Service;
 
 use App\Blog\Application\ApiProxy\UserProxy;
 use App\Blog\Application\Service\Interfaces\CommentNotificationMailerInterface;
+use App\Blog\Domain\Entity\Comment;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
@@ -50,14 +51,13 @@ class CommentNotificationMailer implements CommentNotificationMailerInterface
      */
     public function sendCommentNotificationEmail(string $userId, string $commentAuthorId, string $slug): void
     {
-        $users = $this->userProxy->getUsers();
-        $usersById = [];
+        $usersById = $this->getUsersById();
+        $user = $usersById[$userId] ?? null;
+        $commentAuthor = $usersById[$commentAuthorId] ?? null;
 
-        foreach ($users as $user) {
-            $usersById[$user['id']] = $user;
+        if ($user === null || $commentAuthor === null) {
+            return;
         }
-        $user = $usersById[$userId];
-        $commentAuthor = $usersById[$commentAuthorId];
 
         $email = (new Email())
             ->from('admin@bro-world.de')
@@ -72,5 +72,92 @@ class CommentNotificationMailer implements CommentNotificationMailerInterface
             );
 
         $this->mailer->send($email);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws LoaderError
+     * @throws RedirectionExceptionInterface
+     * @throws RuntimeError
+     * @throws ServerExceptionInterface
+     * @throws SyntaxError
+     * @throws TransportExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
+    public function sendCommentReplyNotificationEmail(
+        string $commentOwnerId,
+        string $replyAuthorId,
+        Comment $reply
+    ): void {
+        $slug = $this->resolveSlug($reply);
+        if ($slug === null) {
+            return;
+        }
+
+        $usersById = $this->getUsersById();
+        $commentOwner = $usersById[$commentOwnerId] ?? null;
+        $replyAuthor = $usersById[$replyAuthorId] ?? null;
+
+        if ($commentOwner === null || $replyAuthor === null) {
+            return;
+        }
+
+        $email = (new Email())
+            ->from('admin@bro-world.de')
+            ->to($commentOwner['email'])
+            ->subject('New reply to your comment')
+            ->html(
+                $this->twig->render(
+                    'Emails/comment_reply.html.twig',
+                    [
+                        'user' => $commentOwner['firstName'],
+                        'commentAuthor' => $replyAuthor['firstName'],
+                        'slug' => $slug,
+                        'comment' => $reply->getContent(),
+                    ]
+                )
+            );
+
+        $this->mailer->send($email);
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     *
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
+    private function getUsersById(): array
+    {
+        $users = $this->userProxy->getUsers();
+        $usersById = [];
+
+        foreach ($users as $user) {
+            if (isset($user['id'])) {
+                $usersById[$user['id']] = $user;
+            }
+        }
+
+        return $usersById;
+    }
+
+    private function resolveSlug(Comment $comment): ?string
+    {
+        $current = $comment;
+
+        while ($current !== null) {
+            $post = $current->getPost();
+            if ($post !== null && $post->getSlug() !== null) {
+                return $post->getSlug();
+            }
+
+            $current = $current->getParent();
+        }
+
+        return null;
     }
 }

--- a/src/Blog/Application/Service/Interfaces/CommentNotificationMailerInterface.php
+++ b/src/Blog/Application/Service/Interfaces/CommentNotificationMailerInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Blog\Application\Service\Interfaces;
 
+use App\Blog\Domain\Entity\Comment;
+
 interface CommentNotificationMailerInterface
 {
     /**
@@ -17,4 +19,10 @@ interface CommentNotificationMailerInterface
      *      #managing-roles-in-the-database
      */
     public function sendCommentNotificationEmail(string $userId, string $commentAuthorId, string $slug): void;
+
+    public function sendCommentReplyNotificationEmail(
+        string $commentOwnerId,
+        string $replyAuthorId,
+        Comment $reply
+    ): void;
 }

--- a/src/Blog/Transport/Controller/Frontend/Comment/CommentCommentController.php
+++ b/src/Blog/Transport/Controller/Frontend/Comment/CommentCommentController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\Controller\Frontend\Comment;
 
+use App\Blog\Application\Service\Interfaces\CommentNotificationMailerInterface;
 use App\Blog\Application\Service\NotificationService;
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;
@@ -37,7 +38,8 @@ readonly class CommentCommentController
     public function __construct(
         private SerializerInterface $serializer,
         private CommentRepositoryInterface $commentRepository,
-        private NotificationService $notificationService
+        private NotificationService $notificationService,
+        private CommentNotificationMailerInterface $commentNotificationMailer
     ) {
     }
 
@@ -74,6 +76,12 @@ readonly class CommentCommentController
         );
 
         $this->commentRepository->save($newComment);
+
+        $this->commentNotificationMailer->sendCommentReplyNotificationEmail(
+            $comment->getAuthor()->toString(),
+            $symfonyUser->getUserIdentifier(),
+            $newComment
+        );
 
         $output = JSON::decode(
             $this->serializer->serialize(

--- a/templates/Emails/comment_reply.html.twig
+++ b/templates/Emails/comment_reply.html.twig
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>New Reply Notification</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 600px;
+            margin: 30px auto;
+            background: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+        }
+        h1 {
+            color: #333;
+        }
+        p {
+            font-size: 16px;
+            color: #555;
+        }
+        blockquote {
+            margin: 20px 0;
+            padding: 15px;
+            background: #f9f9f9;
+            border-left: 4px solid #007bff;
+            color: #333;
+        }
+        .btn {
+            display: inline-block;
+            margin-top: 20px;
+            padding: 12px 20px;
+            font-size: 16px;
+            color: #fff;
+            background: #007bff;
+            text-decoration: none;
+            border-radius: 5px;
+        }
+        .btn:hover {
+            background: #0056b3;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Hi, {{ user }}!</h1>
+    <p>{{ commentAuthor }} replied to your comment.</p>
+    {% if comment %}
+        <blockquote>{{ comment }}</blockquote>
+    {% endif %}
+    <a class="btn" href="https://bro-world-space.com/post/{{ slug }}">View Conversation</a>
+</div>
+</body>
+</html>

--- a/tests/Unit/Blog/Transport/Controller/Frontend/Comment/CommentCommentControllerTest.php
+++ b/tests/Unit/Blog/Transport/Controller/Frontend/Comment/CommentCommentControllerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Blog\Transport\Controller\Frontend\Comment;
+
+use App\Blog\Application\Service\Interfaces\CommentNotificationMailerInterface;
+use App\Blog\Application\Service\NotificationService;
+use App\Blog\Domain\Entity\Comment;
+use App\Blog\Domain\Entity\Post;
+use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;
+use App\Blog\Transport\Controller\Frontend\Comment\CommentCommentController;
+use App\General\Infrastructure\ValueObject\SymfonyUser;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class CommentCommentControllerTest extends TestCase
+{
+    private SerializerInterface&MockObject $serializer;
+    private CommentRepositoryInterface&MockObject $commentRepository;
+    private NotificationService&MockObject $notificationService;
+    private CommentNotificationMailerInterface&MockObject $commentNotificationMailer;
+
+    protected function setUp(): void
+    {
+        $this->serializer = $this->createMock(SerializerInterface::class);
+        $this->commentRepository = $this->createMock(CommentRepositoryInterface::class);
+        $this->notificationService = $this->createMock(NotificationService::class);
+        $this->commentNotificationMailer = $this->createMock(CommentNotificationMailerInterface::class);
+    }
+
+    public function testReplyingToCommentTriggersMailer(): void
+    {
+        $controller = new CommentCommentController(
+            $this->serializer,
+            $this->commentRepository,
+            $this->notificationService,
+            $this->commentNotificationMailer
+        );
+
+        $parentAuthorId = '00000000-0000-0000-0000-000000000001';
+        $replyAuthorId = '00000000-0000-0000-0000-000000000002';
+
+        $parentComment = new Comment();
+        $parentComment->setAuthor(Uuid::fromString($parentAuthorId));
+
+        $post = $this->createMock(Post::class);
+        $post->method('getId')->willReturn('post-id');
+        $post->method('getSlug')->willReturn('post-slug');
+        $parentComment->setPost($post);
+
+        $request = new Request(
+            [],
+            [
+                'content' => 'Thanks for your insight!',
+            ],
+            [],
+            [],
+            [],
+            [
+                'HTTP_AUTHORIZATION' => 'Bearer token',
+            ]
+        );
+
+        $symfonyUser = new SymfonyUser($replyAuthorId, null, null, []);
+
+        $this->commentRepository
+            ->expects(self::once())
+            ->method('save')
+            ->with(self::callback(static function (Comment $comment) use ($parentComment, $replyAuthorId) {
+                self::assertSame($parentComment, $comment->getParent());
+                self::assertSame($replyAuthorId, $comment->getAuthor()->toString());
+
+                return true;
+            }));
+
+        $this->notificationService
+            ->expects(self::once())
+            ->method('createNotification')
+            ->with(
+                'Bearer token',
+                'PUSH',
+                $replyAuthorId,
+                $parentAuthorId,
+                'post-id',
+                'commented on your comment.'
+            );
+
+        $this->serializer
+            ->expects(self::once())
+            ->method('serialize')
+            ->with(self::isInstanceOf(Comment::class), 'json', ['groups' => 'Comment'])
+            ->willReturn('{}');
+
+        $this->commentNotificationMailer
+            ->expects(self::once())
+            ->method('sendCommentReplyNotificationEmail')
+            ->with(
+                $parentAuthorId,
+                $replyAuthorId,
+                self::callback(static function (Comment $comment) use ($parentComment) {
+                    return $comment->getParent() === $parentComment;
+                })
+            );
+
+        $response = $controller->__invoke($symfonyUser, $request, $parentComment);
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary
- extend the comment notification mailer interface with a method dedicated to reply notifications
- implement the reply mailer with slug fallbacks and a Twig template for reply emails
- trigger the mailer from the reply controller and add a unit test covering the new behaviour

## Testing
- vendor/bin/phpunit --testsuite=Unit --filter CommentCommentControllerTest *(fails: phpunit executable not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d35e96debc8326928d42325932052e