### PR TITLE
Add reaction notification emails for post and comment reactions

### DIFF
--- a/src/Blog/Application/Service/Interfaces/ReactionNotificationMailerInterface.php
+++ b/src/Blog/Application/Service/Interfaces/ReactionNotificationMailerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Service\Interfaces;
+
+interface ReactionNotificationMailerInterface
+{
+    public function sendPostReactionNotificationEmail(string $postAuthorId, string $reactorId, ?string $postSlug): void;
+
+    public function sendCommentReactionNotificationEmail(string $commentAuthorId, string $reactorId, ?string $postSlug): void;
+}

--- a/src/Blog/Application/Service/ReactionNotificationMailer.php
+++ b/src/Blog/Application/Service/ReactionNotificationMailer.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Service;
+
+use App\Blog\Application\ApiProxy\UserProxy;
+use App\Blog\Application\Service\Interfaces\ReactionNotificationMailerInterface;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface as MailerTransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
+
+class ReactionNotificationMailer implements ReactionNotificationMailerInterface
+{
+    public function __construct(
+        private readonly UserProxy $userProxy,
+        private readonly MailerInterface $mailer,
+        private readonly Environment $twig
+    ) {
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     * @throws MailerTransportExceptionInterface
+     */
+    public function sendPostReactionNotificationEmail(string $postAuthorId, string $reactorId, ?string $postSlug): void
+    {
+        $this->sendReactionEmail(
+            $postAuthorId,
+            $reactorId,
+            'Emails/post_reaction.html.twig',
+            'Someone reacted to your post',
+            $postSlug
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     * @throws MailerTransportExceptionInterface
+     */
+    public function sendCommentReactionNotificationEmail(string $commentAuthorId, string $reactorId, ?string $postSlug): void
+    {
+        $this->sendReactionEmail(
+            $commentAuthorId,
+            $reactorId,
+            'Emails/comment_reaction.html.twig',
+            'Someone reacted to your comment',
+            $postSlug
+        );
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws ClientExceptionInterface
+     * @throws DecodingExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     * @throws MailerTransportExceptionInterface
+     */
+    private function sendReactionEmail(
+        string $recipientId,
+        string $reactorId,
+        string $template,
+        string $subject,
+        ?string $postSlug
+    ): void {
+        if ($recipientId === $reactorId) {
+            return;
+        }
+
+        $users = $this->userProxy->batchSearchUsers([$recipientId, $reactorId]);
+        $recipient = $users[$recipientId] ?? null;
+        $reactor = $users[$reactorId] ?? null;
+
+        if ($recipient === null || $reactor === null || empty($recipient['email'])) {
+            return;
+        }
+
+        $email = (new Email())
+            ->from('admin@bro-world.de')
+            ->to($recipient['email'])
+            ->subject($subject)
+            ->html(
+                $this->twig->render($template, [
+                    'recipient' => $recipient['firstName'] ?? $recipient['email'],
+                    'reactor' => $reactor['firstName'] ?? $reactor['email'] ?? 'Someone',
+                    'slug' => $postSlug,
+                ])
+            );
+
+        $this->mailer->send($email);
+    }
+}

--- a/src/Blog/Transport/Controller/Frontend/React/ReactPostController.php
+++ b/src/Blog/Transport/Controller/Frontend/React/ReactPostController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\Controller\Frontend\React;
 
+use App\Blog\Application\Service\Interfaces\ReactionNotificationMailerInterface;
 use App\Blog\Domain\Entity\Post;
 use App\Blog\Domain\Entity\Reaction;
 use App\Blog\Domain\Message\CreateNotificationMessenger;
@@ -35,7 +36,8 @@ readonly class ReactPostController
     public function __construct(
         private SerializerInterface $serializer,
         private ReactionRepositoryInterface $reactionRepository,
-        private MessageBusInterface $bus
+        private MessageBusInterface $bus,
+        private ReactionNotificationMailerInterface $reactionNotificationMailer
     ) {
     }
 
@@ -106,6 +108,12 @@ readonly class ReactPostController
                 $post->getId(),
                 'reacted to your post.'
             )
+        );
+
+        $this->reactionNotificationMailer->sendPostReactionNotificationEmail(
+            $post->getAuthor()->toString(),
+            $symfonyUser->getUserIdentifier(),
+            $post->getSlug()
         );
 
         $this->reactionRepository->save($reaction);

--- a/src/Blog/Transport/Controller/Frontend/React/ToggleCommentController.php
+++ b/src/Blog/Transport/Controller/Frontend/React/ToggleCommentController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\Controller\Frontend\React;
 
+use App\Blog\Application\Service\Interfaces\ReactionNotificationMailerInterface;
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Entity\Like;
 use App\Blog\Domain\Message\CreateNotificationMessenger;
@@ -33,7 +34,8 @@ readonly class ToggleCommentController
     public function __construct(
         private SerializerInterface $serializer,
         private LikeRepositoryInterface $likeRepository,
-        private MessageBusInterface $bus
+        private MessageBusInterface $bus,
+        private ReactionNotificationMailerInterface $reactionNotificationMailer
     ) {
     }
 
@@ -61,6 +63,12 @@ readonly class ToggleCommentController
                 $comment->getPost()?->getId(),
                 'liked your comment.'
             )
+        );
+
+        $this->reactionNotificationMailer->sendCommentReactionNotificationEmail(
+            $comment->getAuthor()->toString(),
+            $symfonyUser->getUserIdentifier(),
+            $comment->getPost()?->getSlug()
         );
         $this->likeRepository->save($like);
         $result = [];

--- a/templates/Emails/comment_reaction.html.twig
+++ b/templates/Emails/comment_reaction.html.twig
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Comment Reaction Notification</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 600px;
+            margin: 30px auto;
+            background: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            text-align: center;
+        }
+        h1 {
+            color: #333;
+        }
+        p {
+            font-size: 16px;
+            color: #555;
+        }
+        .btn {
+            display: inline-block;
+            margin-top: 20px;
+            padding: 12px 20px;
+            font-size: 16px;
+            color: #fff;
+            background: #007bff;
+            text-decoration: none;
+            border-radius: 5px;
+        }
+        .btn:hover {
+            background: #0056b3;
+        }
+        .footer {
+            margin-top: 20px;
+            font-size: 12px;
+            color: #777;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Hi, {{ recipient }}!</h1>
+    <p>{{ reactor }} reacted to your comment.</p>
+    {% if slug %}
+        <a class="btn" href="https://bro-world-space.com/post/{{ slug }}">View Post</a>
+    {% endif %}
+    <p class="footer">You're receiving this email because you have a Bro World account.</p>
+</div>
+</body>
+</html>

--- a/templates/Emails/post_reaction.html.twig
+++ b/templates/Emails/post_reaction.html.twig
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Post Reaction Notification</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 0;
+        }
+        .container {
+            max-width: 600px;
+            margin: 30px auto;
+            background: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+            text-align: center;
+        }
+        h1 {
+            color: #333;
+        }
+        p {
+            font-size: 16px;
+            color: #555;
+        }
+        .btn {
+            display: inline-block;
+            margin-top: 20px;
+            padding: 12px 20px;
+            font-size: 16px;
+            color: #fff;
+            background: #007bff;
+            text-decoration: none;
+            border-radius: 5px;
+        }
+        .btn:hover {
+            background: #0056b3;
+        }
+        .footer {
+            margin-top: 20px;
+            font-size: 12px;
+            color: #777;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Hi, {{ recipient }}!</h1>
+    <p>{{ reactor }} reacted to your post.</p>
+    {% if slug %}
+        <a class="btn" href="https://bro-world-space.com/post/{{ slug }}">View Post</a>
+    {% endif %}
+    <p class="footer">You're receiving this email because you have a Bro World account.</p>
+</div>
+</body>
+</html>

--- a/tests/Unit/Blog/Transport/Controller/Frontend/React/ReactPostControllerTest.php
+++ b/tests/Unit/Blog/Transport/Controller/Frontend/React/ReactPostControllerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Blog\Transport\Controller\Frontend\React;
+
+use App\Blog\Application\Service\Interfaces\ReactionNotificationMailerInterface;
+use App\Blog\Domain\Entity\Post;
+use App\Blog\Domain\Entity\Reaction;
+use App\Blog\Domain\Repository\Interfaces\ReactionRepositoryInterface;
+use App\Blog\Transport\Controller\Frontend\React\ReactPostController;
+use App\General\Infrastructure\ValueObject\SymfonyUser;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+use function json_encode;
+
+final class ReactPostControllerTest extends TestCase
+{
+    /** @var SerializerInterface */
+    private $serializer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->serializer = new class() implements SerializerInterface {
+            public function serialize($data, string $format, array $context = []): string
+            {
+                return (string)json_encode($data);
+            }
+
+            public function deserialize($data, string $type, string $format, array $context = []): mixed
+            {
+                throw new \BadMethodCallException('Not needed in tests.');
+            }
+        };
+    }
+
+    public function testMailerIsTriggeredWhenReactionIsCreated(): void
+    {
+        $postAuthor = Uuid::uuid4();
+        $reactor = Uuid::uuid4();
+        $post = $this->createPost($postAuthor, 'my-post-slug');
+
+        $reactionRepository = new class() implements ReactionRepositoryInterface {
+            public ?Reaction $saved = null;
+
+            public function findOneBy(array $criteria, ?array $orderBy = null)
+            {
+                return null;
+            }
+
+            public function save(Reaction $reaction): void
+            {
+                $this->saved = $reaction;
+            }
+
+            public function remove(Reaction $reaction): void
+            {
+            }
+        };
+
+        /** @var MessageBusInterface&MockObject $bus */
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())->method('dispatch');
+
+        /** @var ReactionNotificationMailerInterface&MockObject $mailer */
+        $mailer = $this->createMock(ReactionNotificationMailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('sendPostReactionNotificationEmail')
+            ->with($postAuthor->toString(), $reactor->toString(), 'my-post-slug');
+
+        $controller = new ReactPostController(
+            $this->serializer,
+            $reactionRepository,
+            $bus,
+            $mailer
+        );
+
+        $symfonyUser = new SymfonyUser($reactor->toString(), 'Reactor', null, []);
+        $request = new Request([], [], ['type' => 'like'], [], [], ['HTTP_AUTHORIZATION' => 'Bearer token']);
+
+        $controller($symfonyUser, $request, $post, 'like');
+
+        self::assertInstanceOf(Reaction::class, $reactionRepository->saved);
+        self::assertSame('like', $reactionRepository->saved?->getType());
+    }
+
+    private function createPost(UuidInterface $author, string $slug): Post
+    {
+        $post = new Post();
+        $post->setAuthor($author);
+        $post->setSlug($slug);
+
+        return $post;
+    }
+}

--- a/tests/Unit/Blog/Transport/Controller/Frontend/React/ToggleCommentControllerTest.php
+++ b/tests/Unit/Blog/Transport/Controller/Frontend/React/ToggleCommentControllerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Blog\Transport\Controller\Frontend\React;
+
+use App\Blog\Application\Service\Interfaces\ReactionNotificationMailerInterface;
+use App\Blog\Domain\Entity\Comment;
+use App\Blog\Domain\Entity\Like;
+use App\Blog\Domain\Entity\Post;
+use App\Blog\Domain\Repository\Interfaces\LikeRepositoryInterface;
+use App\Blog\Transport\Controller\Frontend\React\ToggleCommentController;
+use App\General\Infrastructure\ValueObject\SymfonyUser;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+use function json_encode;
+
+final class ToggleCommentControllerTest extends TestCase
+{
+    /** @var SerializerInterface */
+    private $serializer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->serializer = new class() implements SerializerInterface {
+            public function serialize($data, string $format, array $context = []): string
+            {
+                return (string)json_encode($data);
+            }
+
+            public function deserialize($data, string $type, string $format, array $context = []): mixed
+            {
+                throw new \BadMethodCallException('Not needed in tests.');
+            }
+        };
+    }
+
+    public function testMailerIsTriggeredWhenCommentIsLiked(): void
+    {
+        $commentAuthorId = Uuid::uuid4()->toString();
+        $reactorId = Uuid::uuid4()->toString();
+
+        $post = new Post();
+        $post->setAuthor(Uuid::fromString($commentAuthorId));
+        $post->setSlug('post-slug');
+
+        $comment = new Comment();
+        $comment->setAuthor(Uuid::fromString($commentAuthorId));
+        $comment->setPost($post);
+
+        $likeRepository = new class() implements LikeRepositoryInterface {
+            public ?Like $saved = null;
+
+            public function countLikesByMonth(): array
+            {
+                return [];
+            }
+
+            public function save(Like $like): void
+            {
+                $this->saved = $like;
+            }
+        };
+
+        /** @var MessageBusInterface&MockObject $bus */
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects(self::once())->method('dispatch');
+
+        /** @var ReactionNotificationMailerInterface&MockObject $mailer */
+        $mailer = $this->createMock(ReactionNotificationMailerInterface::class);
+        $mailer->expects(self::once())
+            ->method('sendCommentReactionNotificationEmail')
+            ->with($commentAuthorId, $reactorId, 'post-slug');
+
+        $controller = new ToggleCommentController(
+            $this->serializer,
+            $likeRepository,
+            $bus,
+            $mailer
+        );
+
+        $symfonyUser = new SymfonyUser($reactorId, 'Reactor', null, []);
+        $request = new Request([], [], [], [], [], ['HTTP_AUTHORIZATION' => 'Bearer token']);
+
+        $controller($symfonyUser, $request, $comment);
+
+        self::assertInstanceOf(Like::class, $likeRepository->saved);
+        self::assertSame($reactorId, $likeRepository->saved?->getUser()->toString());
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated reaction notification mailer and interface to build post/comment email alerts
- provide Twig templates for the new post and comment reaction notifications
- trigger the mailer from post and comment reaction controllers and cover the behavior with unit tests

## Testing
- ⚠️ `vendor/bin/phpunit` *(not run: project dependencies are unavailable in the container because Composer install fails with repeated 403 errors when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d35e9dfa988326a28933545a14e60b