### PR TITLE
Fix post slug generation via listener

### DIFF
--- a/src/Blog/Application/Service/PostService.php
+++ b/src/Blog/Application/Service/PostService.php
@@ -34,6 +34,7 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Throwable;
 use Traversable;
 
+use function array_key_exists;
 use function iterator_to_array;
 use function sprintf;
 use function strlen;
@@ -127,10 +128,17 @@ readonly class PostService
     {
         $data = $request->request->all();
 
+        $title = $data['title'] ?? '';
+        $slug = $data['slug'] ?? null;
+
+        if ($slug === null && !array_key_exists('title', $data)) {
+            $slug = $this->generateRandomString(20);
+        }
+
         $post = (new Post())
             ->setAuthor(Uuid::fromString($user->getUserIdentifier()))
-            ->setTitle($data['title'] ?? '')
-            ->setSlug($data['title'] ?? $this->generateRandomString(20));
+            ->setTitle($title)
+            ->setSlug($slug);
 
         $post->setUrl($data['url'] ?? '');
         $post->setContent($data['content'] ?? '');

--- a/src/Blog/Transport/Controller/Frontend/Post/EditPostController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/EditPostController.php
@@ -25,7 +25,9 @@ use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Throwable;
 
+use function array_key_exists;
 use function strlen;
+use function trim;
 
 /**
  * @package App\Blog
@@ -59,9 +61,15 @@ readonly class EditPostController
     {
         $data = $request->request->all();
 
-        if (isset($data['title'])) {
-            $post->setTitle($data['title']);
-            $post->setSlug($data['title'] ?? $this->generateRandomString(20));
+        if (array_key_exists('title', $data)) {
+            $title = $data['title'];
+            $post->setTitle($title);
+
+            if (array_key_exists('slug', $data)) {
+                $post->setSlug($data['slug']);
+            } elseif (trim((string)$title) !== '') {
+                $post->setSlug(null);
+            }
         }
         if (isset($data['content'])) {
             $post->setContent($data['content']);

--- a/tests/Application/Blog/Application/Service/PostServiceTest.php
+++ b/tests/Application/Blog/Application/Service/PostServiceTest.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace App\Tests\Application\Blog\Application\Service;
 
 use App\Blog\Application\Service\PostService;
+use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Entity\Post;
+use App\General\Infrastructure\ValueObject\SymfonyUser;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @package App\Tests\Application\Blog\Application\Service
@@ -37,5 +41,45 @@ class PostServiceTest extends KernelTestCase
         self::assertSame([
             'error' => 'No files uploaded.',
         ], $data);
+    }
+
+    #[TestDox('Persisting a post with a title generates a slug from that title.')]
+    public function testSlugIsGeneratedWhenPersistingPost(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        $service = $container->get(PostService::class);
+
+        /** @var ManagerRegistry $registry */
+        $registry = $container->get(ManagerRegistry::class);
+        $entityManager = $registry->getManager();
+
+        $authorId = Uuid::uuid4();
+
+        $blog = (new Blog())
+            ->setTitle('Test Blog')
+            ->setAuthor($authorId)
+            ->setSlug('test-blog');
+
+        $user = new SymfonyUser($authorId->toString(), 'Test User', null, ['ROLE_USER']);
+        $request = new Request([], [
+            'title' => 'My Post Title',
+        ]);
+
+        $post = $service->generatePostAttributes($blog, $user, $request);
+        $post->setBlog($blog);
+
+        self::assertSame('', $post->getSlug());
+
+        $entityManager->persist($blog);
+        $entityManager->persist($post);
+        $entityManager->flush();
+
+        self::assertSame('my-post-title', $post->getSlug());
+
+        $entityManager->remove($post);
+        $entityManager->remove($blog);
+        $entityManager->flush();
     }
 }


### PR DESCRIPTION
## Summary
- clear generated post slugs when titles are provided so the slug listener can slugify them
- apply the same slug handling when editing posts from the frontend controller
- add a service test to ensure persisting "My Post Title" stores the slug as "my-post-title"

## Testing
- php -l src/Blog/Application/Service/PostService.php
- php -l src/Blog/Transport/Controller/Frontend/Post/EditPostController.php
- php -l tests/Application/Blog/Application/Service/PostServiceTest.php


------
https://chatgpt.com/codex/tasks/task_e_68d362e391b883268073716446440e9d