### PR TITLE
Implement content moderation for posts and comments

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -10,6 +10,12 @@ parameters:
     api_notification_base_url: '%env(API_NOTIFICATION_BASE_URL)%'
     logo_directory: '%kernel.project_dir%/public/uploads/logo'
     post_directory: '%kernel.project_dir%/public/uploads/post'
+    app.moderation.banned_words:
+        - spam
+        - violence
+        - terror
+        - abuse
+        - scam
 services:
     # default configuration for services in *this* file
     _defaults:
@@ -140,6 +146,10 @@ services:
     App\Blog\Application\Service\PostService:
         arguments:
             $postDirectory: '%post_directory%'
+
+    App\Blog\Application\Service\ContentModerationService:
+        arguments:
+            $bannedWords: '%app.moderation.banned_words%'
 
     Symfony\Contracts\Cache\TagAwareCacheInterface: '@cache.app.taggable'
 

--- a/src/Blog/Application/Service/CommentService.php
+++ b/src/Blog/Application/Service/CommentService.php
@@ -29,13 +29,15 @@ readonly class CommentService
      * @throws OptimisticLockException
      * @throws TransactionRequiredException
      */
-    public function saveComment(Comment $comment, ?string $postId, ?string $userId, ?array $data): void
+    public function saveComment(Comment $comment, ?string $postId, ?string $userId, ?array $data): Comment
     {
         $post = $this->postRepository->find($postId);
         $comment->setPost($post);
         $comment->setAuthor(Uuid::fromString($userId));
         $comment->setContent($data['content']);
         $this->commentRepository->save($comment);
+
+        return $comment;
     }
 
     public function commentToArray($comment, $usersById): array

--- a/src/Blog/Application/Service/ContentModerationService.php
+++ b/src/Blog/Application/Service/ContentModerationService.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Service;
+
+use function array_unique;
+use function mb_strtolower;
+use function trim;
+
+final readonly class ContentModerationService
+{
+    /**
+     * @param array<int, string> $bannedWords
+     */
+    public function __construct(private array $bannedWords)
+    {
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function detectViolations(?string $content): array
+    {
+        if ($content === null || trim($content) === '') {
+            return [];
+        }
+
+        $normalized = mb_strtolower($content);
+        $violations = [];
+
+        foreach ($this->bannedWords as $word) {
+            $word = trim($word);
+
+            if ($word === '') {
+                continue;
+            }
+
+            if (str_contains($normalized, mb_strtolower($word))) {
+                $violations[] = $word;
+            }
+        }
+
+        return array_values(array_unique($violations));
+    }
+
+    public function isContentAllowed(?string $content): bool
+    {
+        return $this->detectViolations($content) === [];
+    }
+}

--- a/src/Blog/Application/Service/ModerationWarningService.php
+++ b/src/Blog/Application/Service/ModerationWarningService.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Service;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+use function sprintf;
+
+final readonly class ModerationWarningService
+{
+    private const string CACHE_TAG = 'moderation_warnings';
+    private const int WARNING_TTL = 604800; // 7 days
+
+    public function __construct(
+        private TagAwareCacheInterface $cache,
+        private LoggerInterface $logger
+    ) {
+    }
+
+    /**
+     * @param array<int, string> $violations
+     */
+    public function recordWarning(?string $userId, string $subjectType, string $subjectId, array $violations): void
+    {
+        $owner = $userId ?? 'anonymous';
+        $warningCount = $this->incrementWarningCount($owner);
+
+        $this->logger->warning('Content removed by moderation.', [
+            'userId' => $owner,
+            'subjectType' => $subjectType,
+            'subjectId' => $subjectId,
+            'violations' => $violations,
+            'warnings' => $warningCount,
+        ]);
+    }
+
+    private function incrementWarningCount(string $userId): int
+    {
+        $cacheKey = sprintf('moderation_warning_%s', $userId);
+
+        $count = $this->cache->get($cacheKey, function (ItemInterface $item) {
+            $item->tag([self::CACHE_TAG]);
+            $item->expiresAfter(self::WARNING_TTL);
+
+            return 0;
+        });
+
+        $count++;
+
+        $this->cache->delete($cacheKey);
+
+        $this->cache->get($cacheKey, function (ItemInterface $item) use ($count) {
+            $item->tag([self::CACHE_TAG]);
+            $item->expiresAfter(self::WARNING_TTL);
+
+            return $count;
+        });
+
+        return $count;
+    }
+}

--- a/src/Blog/Application/Service/PostService.php
+++ b/src/Blog/Application/Service/PostService.php
@@ -95,12 +95,14 @@ readonly class PostService
      * @throws ORMException
      * @throws OptimisticLockException
      */
-    public function savePost(Post $post, ?array $mediaIds): void
+    public function savePost(Post $post, ?array $mediaIds): Post
     {
         if (!empty($mediaIds)) {
             //$post->setMedias($mediaIds);
         }
         $this->postRepository->save($post);
+
+        return $post;
     }
 
     /**

--- a/src/Blog/Transport/Event/PostCreatedEvent.php
+++ b/src/Blog/Transport/Event/PostCreatedEvent.php
@@ -2,25 +2,12 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Symfony package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace App\Blog\Transport\Event;
 
-use App\Blog\Domain\Entity\Comment;
+use App\Blog\Domain\Entity\Post;
 use Symfony\Contracts\EventDispatcher\Event;
 
-/**
- * @package App\Blog\Transport\Event
- * @author  Rami Aouinti <rami.aouinti@tkdeutschland.de>
- */
-final class CommentCreatedEvent extends Event
+final class PostCreatedEvent extends Event
 {
     private bool $blocked = false;
 
@@ -31,13 +18,13 @@ final class CommentCreatedEvent extends Event
     private ?string $reason = null;
 
     public function __construct(
-        private readonly Comment $comment
+        private readonly Post $post
     ) {
     }
 
-    public function getComment(): Comment
+    public function getPost(): Post
     {
-        return $this->comment;
+        return $this->post;
     }
 
     /**

--- a/src/Blog/Transport/EventSubscriber/ContentModerationSubscriber.php
+++ b/src/Blog/Transport/EventSubscriber/ContentModerationSubscriber.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Transport\EventSubscriber;
+
+use App\Blog\Application\Service\ContentModerationService;
+use App\Blog\Application\Service\ModerationWarningService;
+use App\Blog\Domain\Entity\Comment;
+use App\Blog\Domain\Entity\Post;
+use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;
+use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;
+use App\Blog\Transport\Event\CommentCreatedEvent;
+use App\Blog\Transport\Event\PostCreatedEvent;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\TransactionRequiredException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use function array_merge;
+use function array_unique;
+use function array_values;
+
+final readonly class ContentModerationSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private ContentModerationService $moderationService,
+        private ModerationWarningService $warningService,
+        private CommentRepositoryInterface $commentRepository,
+        private PostRepositoryInterface $postRepository,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            CommentCreatedEvent::class => 'onCommentCreated',
+            PostCreatedEvent::class => 'onPostCreated',
+        ];
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     * @throws TransactionRequiredException
+     */
+    public function onCommentCreated(CommentCreatedEvent $event): void
+    {
+        $comment = $event->getComment();
+        $violations = $this->moderationService->detectViolations($comment->getContent());
+
+        if ($violations === []) {
+            return;
+        }
+
+        $this->removeComment($comment);
+        $event->block($violations, 'comment_blocked');
+
+        $this->warningService->recordWarning(
+            $comment->getAuthor()->toString(),
+            'comment',
+            $comment->getId(),
+            $violations
+        );
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     * @throws TransactionRequiredException
+     */
+    public function onPostCreated(PostCreatedEvent $event): void
+    {
+        $post = $event->getPost();
+        $violations = $this->detectPostViolations($post);
+
+        if ($violations === []) {
+            return;
+        }
+
+        $this->removePost($post);
+        $event->block($violations, 'post_blocked');
+
+        $this->warningService->recordWarning(
+            $post->getAuthor()->toString(),
+            'post',
+            $post->getId(),
+            $violations
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function detectPostViolations(Post $post): array
+    {
+        $violations = $this->moderationService->detectViolations($post->getTitle());
+        $violations = array_merge($violations, $this->moderationService->detectViolations($post->getSummary()));
+        $violations = array_merge($violations, $this->moderationService->detectViolations($post->getContent()));
+
+        return array_values(array_unique($violations));
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     * @throws TransactionRequiredException
+     */
+    private function removeComment(Comment $comment): void
+    {
+        $this->commentRepository->remove($comment);
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     * @throws TransactionRequiredException
+     */
+    private function removePost(Post $post): void
+    {
+        $this->postRepository->remove($post);
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated moderation and warning services backed by configurable banned words
- dispatch post and comment creation events and interrupt follow-up processing when moderation blocks the content
- register an event subscriber that removes flagged posts or comments and records warnings for the offending author

## Testing
- composer validate --no-check-version

------
https://chatgpt.com/codex/tasks/task_e_68d3c5b877d0832698cf2a6449573564