### PR TITLE
Refactor blog services into domain-specific namespaces

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -134,20 +134,24 @@ services:
             $encoders:
                 - '@app.serializer.encoder.json.external_message'
                 -
+    # Shared infrastructure services
     App\General\Infrastructure\Service\ApiProxyService:
         arguments:
             $apiMediaBaseUrl: '%api_media_base_url%'
             $apiNotificationBaseUrl: '%api_notification_base_url%'
 
-    App\Blog\Application\Service\BlogService:
+    # Blog domain services
+    App\Blog\Application\Service\Blog\BlogService:
         arguments:
             $logoDirectory: '%logo_directory%'
 
-    App\Blog\Application\Service\PostService:
+    # Post domain services
+    App\Blog\Application\Service\Post\PostService:
         arguments:
             $postDirectory: '%post_directory%'
 
-    App\Blog\Application\Service\ContentModerationService:
+    # Moderation domain services
+    App\Blog\Application\Service\Moderation\ContentModerationService:
         arguments:
             $bannedWords: '%app.moderation.banned_words%'
 

--- a/src/Blog/Application/ApiProxy/UserProxy.php
+++ b/src/Blog/Application/ApiProxy/UserProxy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Blog\Application\ApiProxy;
 
-use App\Blog\Application\Service\UserCacheService;
+use App\Blog\Application\Service\User\UserCacheService;
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;

--- a/src/Blog/Application/Service/Blog/BlogService.php
+++ b/src/Blog/Application/Service/Blog/BlogService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Blog;
 
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Repository\Interfaces\BlogRepositoryInterface;
@@ -64,7 +64,7 @@ readonly class BlogService
         return $blogObject;
     }
 
-    public function uploadLogo(Request $request): string|JsonResponse
+    public function executeUploadLogoCommand(Request $request): string|JsonResponse
     {
         $files = $request->files->get('files');
         $file = $files[0];

--- a/src/Blog/Application/Service/Blog/ManagementService.php
+++ b/src/Blog/Application/Service/Blog/ManagementService.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Blog;
 
+use App\Blog\Application\Service\Comment\CommentService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 
 /**

--- a/src/Blog/Application/Service/Comment/CommentCacheService.php
+++ b/src/Blog/Application/Service/Comment/CommentCacheService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Comment;
 
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Contracts\Cache\ItemInterface;

--- a/src/Blog/Application/Service/Comment/CommentNotificationMailer.php
+++ b/src/Blog/Application/Service/Comment/CommentNotificationMailer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Comment;
 
 use App\Blog\Application\ApiProxy\UserProxy;
 use App\Blog\Application\Service\Interfaces\CommentNotificationMailerInterface;

--- a/src/Blog/Application/Service/Comment/CommentResponseHelper.php
+++ b/src/Blog/Application/Service/Comment/CommentResponseHelper.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Comment;
 
 use App\Blog\Application\ApiProxy\UserProxy;
 use App\Blog\Domain\Entity\Comment;

--- a/src/Blog/Application/Service/Comment/CommentService.php
+++ b/src/Blog/Application/Service/Comment/CommentService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Comment;
 
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;
@@ -29,7 +29,7 @@ readonly class CommentService
      * @throws OptimisticLockException
      * @throws TransactionRequiredException
      */
-    public function saveComment(Comment $comment, ?string $postId, ?string $userId, ?array $data): Comment
+    public function executeSaveCommentCommand(Comment $comment, ?string $postId, ?string $userId, ?array $data): Comment
     {
         $post = $this->postRepository->find($postId);
         $comment->setPost($post);

--- a/src/Blog/Application/Service/Moderation/ContentModerationService.php
+++ b/src/Blog/Application/Service/Moderation/ContentModerationService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Moderation;
 
 use function array_unique;
 use function mb_strtolower;

--- a/src/Blog/Application/Service/Moderation/ModerationWarningService.php
+++ b/src/Blog/Application/Service/Moderation/ModerationWarningService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Moderation;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\Cache\ItemInterface;

--- a/src/Blog/Application/Service/Notification/NotificationService.php
+++ b/src/Blog/Application/Service/Notification/NotificationService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Notification;
 
 use App\Blog\Application\ApiProxy\UserProxy;
 use App\Blog\Domain\Entity\Post;
@@ -51,7 +51,7 @@ readonly class NotificationService
      * @throws TransportExceptionInterface
      * @throws InvalidArgumentException
      */
-    public function createNotification(
+    public function executeCreateNotificationCommand(
         ?string $token,
         ?string $channel,
         ?string $symfonyUserId,
@@ -90,7 +90,7 @@ readonly class NotificationService
                 'scopeTarget' => '["' . $userId . '"]',
             ];
 
-            $this->createPush($token, $notification);
+            $this->executeCreatePushCommand($token, $notification);
         }
     }
 
@@ -98,7 +98,7 @@ readonly class NotificationService
      * @throws TransportExceptionInterface
      * @throws JsonException
      */
-    public function createPush(
+    public function executeCreatePushCommand(
         ?string $token,
         array $data
     ): void {
@@ -115,7 +115,7 @@ readonly class NotificationService
      * @throws JsonException
      * @throws TransportExceptionInterface
      */
-    public function createEmail(
+    public function executeCreateEmailCommand(
         ?string $token,
         array $data,
         SymfonyUser $user

--- a/src/Blog/Application/Service/Notification/ReactionNotificationMailer.php
+++ b/src/Blog/Application/Service/Notification/ReactionNotificationMailer.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Notification;
 
 use App\Blog\Application\ApiProxy\UserProxy;
 use App\Blog\Application\Service\Interfaces\ReactionNotificationMailerInterface;

--- a/src/Blog/Application/Service/Post/MediaService.php
+++ b/src/Blog/Application/Service/Post/MediaService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Post;
 
 use App\General\Infrastructure\Service\ApiProxyService;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Blog/Application/Service/Post/PostCachePayloadBuilder.php
+++ b/src/Blog/Application/Service/Post/PostCachePayloadBuilder.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Post;
 
 use App\Blog\Application\ApiProxy\UserProxy;
+use App\Blog\Application\Service\Comment\CommentResponseHelper;
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Entity\Post;
 use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;

--- a/src/Blog/Application/Service/Post/PostFeedCacheService.php
+++ b/src/Blog/Application/Service/Post/PostFeedCacheService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Post;
 
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Contracts\Cache\ItemInterface;

--- a/src/Blog/Application/Service/Post/PostFeedResponseBuilder.php
+++ b/src/Blog/Application/Service/Post/PostFeedResponseBuilder.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Post;
 
 use App\Blog\Application\ApiProxy\UserProxy;
 use App\Blog\Domain\Entity\Comment;

--- a/src/Blog/Application/Service/Post/PostService.php
+++ b/src/Blog/Application/Service/Post/PostService.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\Post;
 
 use App\Blog\Application\ApiProxy\UserProxy;
+use App\Blog\Application\Service\Blog\BlogService;
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Entity\Media;
 use App\Blog\Domain\Entity\Post;
@@ -67,7 +68,7 @@ readonly class PostService
      * @throws TransactionRequiredException
      * @throws NotSupported
      */
-    public function createPost(SymfonyUser $user, Request $request): array
+    public function executeCreatePostCommand(SymfonyUser $user, Request $request): array
     {
         $post = $this->generatePostAttributes(
             $this->blogService->getBlog($request, $user),
@@ -95,7 +96,7 @@ readonly class PostService
      * @throws ORMException
      * @throws OptimisticLockException
      */
-    public function savePost(Post $post, ?array $mediaIds): Post
+    public function executeSavePostCommand(Post $post, ?array $mediaIds): Post
     {
         if (!empty($mediaIds)) {
             //$post->setMedias($mediaIds);

--- a/src/Blog/Application/Service/User/UserCacheService.php
+++ b/src/Blog/Application/Service/User/UserCacheService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\User;
 
 use App\Blog\Application\Service\Interfaces\UserCacheServiceInterface;
 use App\Blog\Application\Service\Interfaces\UserElasticsearchServiceInterface;

--- a/src/Blog/Application/Service/User/UserElasticsearchService.php
+++ b/src/Blog/Application/Service/User/UserElasticsearchService.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Blog\Application\Service;
+namespace App\Blog\Application\Service\User;
 
 use App\Blog\Application\Service\Interfaces\UserElasticsearchServiceInterface;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;

--- a/src/Blog/Transport/Command/RefreshBlogCacheCommand.php
+++ b/src/Blog/Transport/Command/RefreshBlogCacheCommand.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\Command;
 
-use App\Blog\Application\Service\CommentCacheService;
-use App\Blog\Application\Service\PostCachePayloadBuilder;
-use App\Blog\Application\Service\PostFeedCacheService;
+use App\Blog\Application\Service\Comment\CommentCacheService;
+use App\Blog\Application\Service\Post\PostCachePayloadBuilder;
+use App\Blog\Application\Service\Post\PostFeedCacheService;
 use App\Blog\Domain\Entity\Post;
 use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;
 use Override;

--- a/src/Blog/Transport/Controller/Frontend/Blog/CreateBlogController.php
+++ b/src/Blog/Transport/Controller/Frontend/Blog/CreateBlogController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\Controller\Frontend\Blog;
 
-use App\Blog\Application\Service\BlogService;
+use App\Blog\Application\Service\Blog\BlogService;
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Repository\Interfaces\BlogRepositoryInterface;
 use App\General\Infrastructure\ValueObject\SymfonyUser;
@@ -46,7 +46,7 @@ readonly class CreateBlogController
         $this->cache->deleteItem("profile_blog_{$symfonyUser->getUserIdentifier()}");
         $blog = new Blog();
         if ($request->files->get('files')) {
-            $logo = $this->blogService->uploadLogo($request);
+            $logo = $this->blogService->executeUploadLogoCommand($request);
             $blog->setLogo($logo);
         }
         $data = $request->request->all();

--- a/src/Blog/Transport/Controller/Frontend/Blog/EditBlogController.php
+++ b/src/Blog/Transport/Controller/Frontend/Blog/EditBlogController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\Controller\Frontend\Blog;
 
-use App\Blog\Application\Service\BlogService;
+use App\Blog\Application\Service\Blog\BlogService;
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Repository\Interfaces\BlogRepositoryInterface;
 use App\General\Infrastructure\ValueObject\SymfonyUser;
@@ -73,7 +73,7 @@ readonly class EditBlogController
 
         $files = $request->files->get('files');
         if ($files) {
-            $logo = $this->blogService->uploadLogo($request);
+            $logo = $this->blogService->executeUploadLogoCommand($request);
             if ($logo instanceof JsonResponse) {
                 return $logo;
             }

--- a/src/Blog/Transport/Controller/Frontend/Comment/CommentCommentController.php
+++ b/src/Blog/Transport/Controller/Frontend/Comment/CommentCommentController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Frontend\Comment;
 
 use App\Blog\Application\Service\Interfaces\CommentNotificationMailerInterface;
-use App\Blog\Application\Service\NotificationService;
+use App\Blog\Application\Service\Notification\NotificationService;
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;
 use App\General\Domain\Utils\JSON;
@@ -66,7 +66,7 @@ readonly class CommentCommentController
         $newComment->setContent($data['content']);
         $newComment->setParent($comment);
 
-        $this->notificationService->createNotification(
+        $this->notificationService->executeCreateNotificationCommand(
             $request->headers->get('Authorization'),
             'PUSH',
             $symfonyUser->getUserIdentifier(),

--- a/src/Blog/Transport/Controller/Frontend/Post/CreatePostController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/CreatePostController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\Controller\Frontend\Post;
 
-use App\Blog\Application\Service\PostService;
+use App\Blog\Application\Service\Post\PostService;
 use App\General\Infrastructure\ValueObject\SymfonyUser;
 use JsonException;
 use OpenApi\Attributes as OA;
@@ -35,7 +35,7 @@ readonly class CreatePostController
     #[Route(path: '/v1/platform/post', name: 'post_create', methods: [Request::METHOD_POST])]
     public function __invoke(SymfonyUser $symfonyUser, Request $request): JsonResponse
     {
-        $response = $this->postService->createPost($symfonyUser, $request);
+        $response = $this->postService->executeCreatePostCommand($symfonyUser, $request);
 
         return new JsonResponse($response);
     }

--- a/src/Blog/Transport/Controller/Frontend/Post/EditPostController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/EditPostController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Frontend\Post;
 
 use App\Blog\Application\ApiProxy\UserProxy;
-use App\Blog\Application\Service\PostService;
+use App\Blog\Application\Service\Post\PostService;
 use App\Blog\Domain\Entity\Media;
 use App\Blog\Domain\Entity\Post;
 use App\Blog\Infrastructure\Repository\PostRepository;

--- a/src/Blog/Transport/Controller/Frontend/Post/LoggedPostsController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/LoggedPostsController.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Frontend\Post;
 
 use App\Blog\Application\ApiProxy\UserProxy;
-use App\Blog\Application\Service\CommentCacheService;
-use App\Blog\Application\Service\CommentResponseHelper;
-use App\Blog\Application\Service\PostFeedResponseBuilder;
+use App\Blog\Application\Service\Comment\CommentCacheService;
+use App\Blog\Application\Service\Comment\CommentResponseHelper;
+use App\Blog\Application\Service\Post\PostFeedResponseBuilder;
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;
 use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;

--- a/src/Blog/Transport/Controller/Frontend/Post/MyPostsController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/MyPostsController.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Frontend\Post;
 
 use App\Blog\Application\ApiProxy\UserProxy;
-use App\Blog\Application\Service\CommentCacheService;
-use App\Blog\Application\Service\CommentResponseHelper;
+use App\Blog\Application\Service\Comment\CommentCacheService;
+use App\Blog\Application\Service\Comment\CommentResponseHelper;
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Entity\Media;
 use App\Blog\Infrastructure\Repository\CommentRepository;

--- a/src/Blog/Transport/Controller/Frontend/Post/PostsController.php
+++ b/src/Blog/Transport/Controller/Frontend/Post/PostsController.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\Controller\Frontend\Post;
 
-use App\Blog\Application\Service\CommentCacheService;
-use App\Blog\Application\Service\PostCachePayloadBuilder;
-use App\Blog\Application\Service\PostFeedCacheService;
+use App\Blog\Application\Service\Comment\CommentCacheService;
+use App\Blog\Application\Service\Post\PostCachePayloadBuilder;
+use App\Blog\Application\Service\Post\PostFeedCacheService;
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;
 use Doctrine\ORM\Exception\ORMException;

--- a/src/Blog/Transport/EventSubscriber/ContentModerationSubscriber.php
+++ b/src/Blog/Transport/EventSubscriber/ContentModerationSubscriber.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\EventSubscriber;
 
-use App\Blog\Application\Service\ContentModerationService;
-use App\Blog\Application\Service\ModerationWarningService;
+use App\Blog\Application\Service\Moderation\ContentModerationService;
+use App\Blog\Application\Service\Moderation\ModerationWarningService;
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Entity\Post;
 use App\Blog\Domain\Repository\Interfaces\CommentRepositoryInterface;

--- a/src/Blog/Transport/MessageHandler/CreateCommentHandlerMessage.php
+++ b/src/Blog/Transport/MessageHandler/CreateCommentHandlerMessage.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\MessageHandler;
 
-use App\Blog\Application\Service\CommentService;
+use App\Blog\Application\Service\Comment\CommentService;
 use App\Blog\Application\Service\Interfaces\CommentNotificationMailerInterface;
 use App\Blog\Domain\Entity\Comment;
 use App\Blog\Domain\Message\CreateCommentMessenger;
@@ -63,7 +63,7 @@ readonly class CreateCommentHandlerMessage
      */
     private function handleMessage(CreateCommentMessenger $message): Comment
     {
-        return $this->commentService->saveComment(
+        return $this->commentService->executeSaveCommentCommand(
             $message->getComment(),
             $message->getPostId(),
             $message->getSenderId(),

--- a/src/Blog/Transport/MessageHandler/CreateNotificationHandlerMessage.php
+++ b/src/Blog/Transport/MessageHandler/CreateNotificationHandlerMessage.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\MessageHandler;
 
-use App\Blog\Application\Service\NotificationService;
+use App\Blog\Application\Service\Notification\NotificationService;
 use App\Blog\Domain\Message\CreateNotificationMessenger;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
@@ -61,7 +61,7 @@ readonly class CreateNotificationHandlerMessage
      */
     private function handleMessage(CreateNotificationMessenger $message): void
     {
-        $this->notificationService->createNotification(
+        $this->notificationService->executeCreateNotificationCommand(
             $message->getToken(),
             $message->getChannel(),
             $message->getSenderId(),

--- a/src/Blog/Transport/MessageHandler/CreatePostHandlerMessage.php
+++ b/src/Blog/Transport/MessageHandler/CreatePostHandlerMessage.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Blog\Transport\MessageHandler;
 
-use App\Blog\Application\Service\PostFeedCacheService;
-use App\Blog\Application\Service\PostFeedResponseBuilder;
-use App\Blog\Application\Service\PostService;
+use App\Blog\Application\Service\Post\PostFeedCacheService;
+use App\Blog\Application\Service\Post\PostFeedResponseBuilder;
+use App\Blog\Application\Service\Post\PostService;
 use App\Blog\Domain\Entity\Post;
 use App\Blog\Domain\Message\CreatePostMessenger;
 use App\Blog\Domain\Repository\Interfaces\PostRepositoryInterface;
@@ -71,6 +71,6 @@ readonly class CreatePostHandlerMessage
      */
     private function handleMessage(CreatePostMessenger $message): Post
     {
-        return $this->postService->savePost($message->getPost(), $message->getMediasIds());
+        return $this->postService->executeSavePostCommand($message->getPost(), $message->getMediasIds());
     }
 }


### PR DESCRIPTION
## Summary
- reorganize blog application services into domain-specific namespaces (Blog, Post, Comment, Moderation, Notification, User)
- update service configuration and all call sites to use the new namespaces
- rename executable service methods to `execute*Command` to emphasize command semantics across controllers and handlers

## Testing
- composer dump-autoload

------
https://chatgpt.com/codex/tasks/task_e_68d3c9b8c9ec832687c7229a7f76f6b4