### PR TITLE
Fix color mode storage adapter

### DIFF
--- a/composables/useThemes.ts
+++ b/composables/useThemes.ts
@@ -1,0 +1,34 @@
+import { useCookie } from '#app'
+import { useColorMode, type UseColorModeOptions } from '@vueuse/core'
+
+type StorageLike = {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+  removeItem: (key: string) => void
+}
+
+function createCookieStorage(key: string): StorageLike {
+  const cookie = useCookie<string | null>(key, { sameSite: 'lax', path: '/' })
+
+  return {
+    getItem: () => cookie.value ?? null,
+    setItem: (_key: string, value: string) => {
+      cookie.value = value
+    },
+    removeItem: () => {
+      cookie.value = null
+    },
+  }
+}
+
+export function useThemes(options: UseColorModeOptions = {}) {
+  const storageKey = options.storageKey ?? 'color-mode'
+
+  const colorMode = useColorMode({
+    storage: createCookieStorage(storageKey),
+    ...options,
+  })
+
+  return { colorMode }
+}
+


### PR DESCRIPTION
## Summary
- add a cookie-backed storage adapter that matches VueUse's StorageLike contract
- wire the useThemes composable to use the new adapter so color mode persistence no longer crashes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9584d3b548326a68c5728315abf72